### PR TITLE
07 Resolving

### DIFF
--- a/interpreter.py
+++ b/interpreter.py
@@ -49,8 +49,9 @@ def execute(frame, stmt):
     if stmt['rule'] == 'assign':
         execAssign(frame, stmt)
 
-def interpret(statements):
-    frame = {}
+def interpret(statements, frame=None):
+    if not frame:
+        frame = {}
     for stmt in statements:
         try:
             execute(frame, stmt)

--- a/interpreter.py
+++ b/interpreter.py
@@ -50,7 +50,7 @@ def execute(frame, stmt):
         execAssign(frame, stmt)
 
 def interpret(statements, frame=None):
-    if not frame:
+    if frame is None:
         frame = {}
     for stmt in statements:
         try:

--- a/interpreter.py
+++ b/interpreter.py
@@ -1,4 +1,4 @@
-from builtin import RuntimeError, LogicError, get
+from builtin import RuntimeError, LogicError
 
 
 
@@ -8,12 +8,12 @@ def evaluate(expr, frame=None):
         if expr['type'] == 'name':
             return expr['word']
         return expr['value']
+    # Passing frames
+    if 'oper' not in expr:
+        return expr
     # Evaluating exprs
     oper = expr['oper']['value']
-    if oper is get:
-        left = frame  # <-- expr['left'] is None
-    else:
-        left = evaluate(expr['left'])
+    left = evaluate(expr['left'])
     right = evaluate(expr['right'])
     return oper(left, right)
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -53,9 +53,5 @@ def interpret(statements, frame=None):
     if frame is None:
         frame = {}
     for stmt in statements:
-        try:
-            execute(frame, stmt)
-        except RuntimeError:
-            print()
-            break
+        execute(frame, stmt)
     return frame

--- a/main.py
+++ b/main.py
@@ -1,8 +1,9 @@
 import sys
 
-from builtin import ParseError, RuntimeError
+from builtin import ParseError, RuntimeError, LogicError
 import scanner
 import parser
+import resolver
 import interpreter
 
 
@@ -19,7 +20,8 @@ def main():
     try:
         tokens = scanner.scan(src)
         statements = parser.parse(tokens)
-    except ParseError as err:
+        statements, frame = resolver.resolve(statements)
+    except ParseError, LogicError as err:
         print(err)
         sys.exit(65)
     try:

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def main():
         tokens = scanner.scan(src)
         statements = parser.parse(tokens)
         statements, frame = resolver.resolve(statements)
-    except ParseError, LogicError as err:
+    except (ParseError, LogicError) as err:
         print(err)
         sys.exit(65)
     try:

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ def main():
     try:
         tokens = scanner.scan(src)
         statements = parser.parse(tokens)
-        statements, frame = resolver.resolve(statements)
+        statements, frame = resolver.inspect(statements)
     except (ParseError, LogicError) as err:
         print(err)
         sys.exit(65)

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def main():
         print(err)
         sys.exit(65)
     try:
-        frame = interpreter.interpret(statements)
+        frame = interpreter.interpret(statements, frame)
         print(frame)
     except RuntimeError as err:
         print(err)

--- a/resolver.py
+++ b/resolver.py
@@ -12,7 +12,7 @@ def verifyDeclare(frame, stmt):
     pass
 
 def verifyAssign(frame, stmt):
-    value = resolve(stmt['expr'], frame)
+    resolve(stmt['expr'], frame)
 
 def verify(frame, stmt):
     if stmt['rule'] == 'output':

--- a/resolver.py
+++ b/resolver.py
@@ -3,6 +3,16 @@ from builtin import LogicError
 
 
 
+def resolve(expr, frame):
+    # Tokens
+    if 'type' in expr:
+        # ignore for now
+        return
+    # Exprs
+    oper = expr['oper']['value']
+    if oper is get:
+        expr['left'] = frame
+
 def verifyOutput(frame, stmt):
     for expr in stmt['exprs']:
         resolve(expr, frame)

--- a/resolver.py
+++ b/resolver.py
@@ -3,8 +3,24 @@ from builtin import LogicError
 
 
 
-def verify(frame, stmt):
+def verifyOutput(frame, stmt):
+    for expr in stmt['exprs']:
+        resolve(expr, frame)
+
+def verifyDeclare(frame, stmt):
+    # No exprs to resolve
     pass
+
+def verifyAssign(frame, stmt):
+    value = resolve(stmt['expr'], frame)
+
+def verify(frame, stmt):
+    if stmt['rule'] == 'output':
+        verifyOutput(frame, stmt)
+    elif stmt['rule'] == 'declare':
+        verifyDeclare(frame, stmt)
+    elif stmt['rule'] == 'assign':
+        verifyAssign(frame, stmt)
 
 def inspect(statements):
     frame = {}

--- a/resolver.py
+++ b/resolver.py
@@ -1,0 +1,17 @@
+from builtin import get
+from builtin import LogicError
+
+
+
+def verify(frame, stmt):
+    pass
+
+def inspect(statements):
+    frame = {}
+    for stmt in statements:
+        try:
+            verify(frame, stmt)
+        except LogicError:
+            print()
+            break
+    return statements, frame


### PR DESCRIPTION
In later statements we will encounter not just names, but possibly subnames, in code like:

```
FUNCTION GetId(Array : ARRAY) RETURNS ARRAY
    DECLARE i : INTEGER
    DECLARE AttrArray[1:Array.Length] OF STRING
    ...
    AttrArray[i] <- Array[i].Id
```

Here, `i` is a name within the `frame` of the `GetId` function, and does not exist in the global `frame`. `Id` is a name within an element of `Array`, and does not exist in `GetId`'s frame, nor in the global frame.

Determining which `frame` to get names from feels like a responsibility beyond the scope of `interpreter.py`. Who should be responsible for determining the `frame` to get a name from?

This process is called **resolving**, and we will build a resolver in this pull request.

> **[resolve](https://www.etymonline.com/word/resolve#etymonline_v_12897) (v.)**
>
> late 14c., _resolven_, "melt, dissolve, reduce to liquid; **separate into component parts**; alter, alter in form or nature by application of physical process," " intransitive sense from c. 1400; from Old French _resolver_ or directly from Latin _resolvere_ "to loosen, loose, unyoke, undo; **explain**; relax; set free; make void, dispel."
>
> **re-**
> word-forming element meaning "back, back from, **back to the original place**;" also "again, anew, once more," also conveying the notion of "undoing" or "backward," etc. (see sense evolution below), c. 1200, from Old French _re_- and directly from Latin _re_- an inseparable prefix meaning "again; **back**; anew, against."