### PR TITLE
08 Static typing

### DIFF
--- a/interpreter.py
+++ b/interpreter.py
@@ -30,15 +30,6 @@ def execDeclare(frame, stmt):
 def execAssign(frame, stmt):
     name = evaluate(stmt['name'], frame)
     value = evaluate(stmt['expr'], frame)
-    if name not in frame:
-        raise LogicError(f'Undeclared name {repr(name)}')
-    # HACK: type-check values before storing
-    frametype = frame[name]['type']
-    valuetype = type(value)
-    if frametype == 'INTEGER' and valuetype != int:
-        raise LogicError(f'Expected {frametype}, got {valuetype}')
-    elif frametype == 'STRING' and valuetype != str:
-        raise LogicError(f'Expected {frametype}, got {valuetype}')
     frame[name]['value'] = value
 
 def execute(frame, stmt):

--- a/interpreter.py
+++ b/interpreter.py
@@ -1,4 +1,4 @@
-from builtin import RuntimeError, LogicError
+from builtin import RuntimeError
 
 
 

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import interpreter
 
 src = '''
 DECLARE Index : INTEGER
-Index <- 1
+Index <- "5"
 OUTPUT Index
 '''
 

--- a/resolver.py
+++ b/resolver.py
@@ -18,13 +18,13 @@ def resolve(expr, frame):
     oper = expr['oper']['value']
     if oper is get:
         expr['left'] = frame
-        name = resolve(expr['right'])
+        name = resolve(expr['right'], frame)
         return frame[name]['type']
     elif oper in (lt, lte, gt, gte, ne, eq):
         return 'BOOLEAN'
     elif oper in (add, sub, mul, div):
-        lefttype = resolve(expr['left'])
-        righttype = resolve(expr['right'])
+        lefttype = resolve(expr['left'], frame)
+        righttype = resolve(expr['right'], frame)
         if lefttype != 'INTEGER':
             raise LogicError(f"{expr['left']} Expected number, got {lefttype}")
         if righttype != 'INTEGER':
@@ -41,7 +41,6 @@ def verifyDeclare(frame, stmt):
     frame[name] = {'type': type_, 'value': None}
 
 def verifyAssign(frame, stmt):
-    breakpoint()
     name = resolve(stmt['name'], frame)
     valuetype = resolve(stmt['expr'], frame)
     if name not in frame:

--- a/resolver.py
+++ b/resolver.py
@@ -1,4 +1,6 @@
 from builtin import get
+from builtin import lt, lte, gt, gte, ne, eq
+from builtin import add, sub, mul, div
 from builtin import LogicError
 
 
@@ -16,6 +18,18 @@ def resolve(expr, frame):
     oper = expr['oper']['value']
     if oper is get:
         expr['left'] = frame
+        name = resolve(expr['right'])
+        return frame[name]['type']
+    elif oper in (lt, lte, gt, gte, ne, eq):
+        return 'BOOLEAN'
+    elif oper in (add, sub, mul, div):
+        lefttype = resolve(expr['left'])
+        righttype = resolve(expr['right'])
+        if lefttype != 'INTEGER':
+            raise LogicError(f"{expr['left']} Expected number, got {lefttype}")
+        if righttype != 'INTEGER':
+            raise LogicError(f"{expr['right']} Expected number, got {righttype}")
+        return 'INTEGER'
 
 def verifyOutput(frame, stmt):
     for expr in stmt['exprs']:

--- a/resolver.py
+++ b/resolver.py
@@ -24,7 +24,8 @@ def verifyDeclare(frame, stmt):
     frame[name] = {'type': type_, 'value': None}
 
 def verifyAssign(frame, stmt):
-    resolve(stmt['expr'], frame)
+    name = resolve(stmt['name'], frame)
+    valuetype = resolve(stmt['expr'], frame)
 
 def verify(frame, stmt):
     if stmt['rule'] == 'output':

--- a/resolver.py
+++ b/resolver.py
@@ -4,10 +4,11 @@ from builtin import LogicError
 
 
 def resolve(expr, frame):
-    # Tokens
+    # Evaluating tokens
     if 'type' in expr:
-        # ignore for now
-        return
+        if expr['type'] == 'name':
+            return expr['word']
+        return expr['value']
     # Exprs
     oper = expr['oper']['value']
     if oper is get:
@@ -18,8 +19,9 @@ def verifyOutput(frame, stmt):
         resolve(expr, frame)
 
 def verifyDeclare(frame, stmt):
-    # No exprs to resolve
-    pass
+    name = resolve(stmt['name'], frame)
+    type_ = resolve(stmt['type'], frame)
+    frame[name] = {'type': type_, 'value': None}
 
 def verifyAssign(frame, stmt):
     resolve(stmt['expr'], frame)

--- a/resolver.py
+++ b/resolver.py
@@ -9,7 +9,10 @@ def resolve(expr, frame):
     # Resolving tokens
     if 'type' in expr:
         if expr['type'] == 'name':
-            return expr['word']
+            name = expr['word']
+            if name not in frame:
+                raise LogicError(f'{name}: Name not declared')
+            return name
         elif expr['type'] in ('integer', 'string'):
             return expr['type'].upper()
         else:
@@ -43,8 +46,6 @@ def verifyDeclare(frame, stmt):
 def verifyAssign(frame, stmt):
     name = resolve(stmt['name'], frame)
     valuetype = resolve(stmt['expr'], frame)
-    if name not in frame:
-        raise LogicError(f'{name}: Name not declared')
     frametype = frame[name]['type']
     if frametype != valuetype:
         raise LogicError(f'Expected {frametype}, got {valuetype}')

--- a/resolver.py
+++ b/resolver.py
@@ -4,12 +4,12 @@ from builtin import LogicError
 
 
 def resolve(expr, frame):
-    # Evaluating tokens
+    # Resolving tokens
     if 'type' in expr:
         if expr['type'] == 'name':
             return expr['word']
         return expr['value']
-    # Exprs
+    # Resolving exprs
     oper = expr['oper']['value']
     if oper is get:
         expr['left'] = frame

--- a/resolver.py
+++ b/resolver.py
@@ -41,6 +41,7 @@ def verifyDeclare(frame, stmt):
     frame[name] = {'type': type_, 'value': None}
 
 def verifyAssign(frame, stmt):
+    breakpoint()
     name = resolve(stmt['name'], frame)
     valuetype = resolve(stmt['expr'], frame)
     if name not in frame:
@@ -60,9 +61,5 @@ def verify(frame, stmt):
 def inspect(statements):
     frame = {}
     for stmt in statements:
-        try:
-            verify(frame, stmt)
-        except LogicError:
-            print()
-            break
+        verify(frame, stmt)
     return statements, frame

--- a/resolver.py
+++ b/resolver.py
@@ -8,8 +8,11 @@ def resolve(expr, frame):
     if 'type' in expr:
         if expr['type'] == 'name':
             return expr['word']
-        return expr['value']
-    # Resolving exprs
+        elif expr['type'] in ('integer', 'string'):
+            return expr['type'].upper()
+        else:
+            # internal error
+            raise TypeError(f'Cannot resolve type for {expr}')    # Resolving exprs
     oper = expr['oper']['value']
     if oper is get:
         expr['left'] = frame
@@ -26,6 +29,11 @@ def verifyDeclare(frame, stmt):
 def verifyAssign(frame, stmt):
     name = resolve(stmt['name'], frame)
     valuetype = resolve(stmt['expr'], frame)
+    if name not in frame:
+        raise LogicError(f'Variable')
+    frametype = frame[name]['type']
+    if frametype != valuetype:
+        raise LogicError(f'Expected {frametype}, got {valuetype}')
 
 def verify(frame, stmt):
     if stmt['rule'] == 'output':

--- a/resolver.py
+++ b/resolver.py
@@ -44,7 +44,7 @@ def verifyAssign(frame, stmt):
     name = resolve(stmt['name'], frame)
     valuetype = resolve(stmt['expr'], frame)
     if name not in frame:
-        raise LogicError(f'Variable')
+        raise LogicError(f'{name}: Name not declared')
     frametype = frame[name]['type']
     if frametype != valuetype:
         raise LogicError(f'Expected {frametype}, got {valuetype}')

--- a/resolver.py
+++ b/resolver.py
@@ -9,10 +9,7 @@ def resolve(expr, frame):
     # Resolving tokens
     if 'type' in expr:
         if expr['type'] == 'name':
-            name = expr['word']
-            if name not in frame:
-                raise LogicError(f'{name}: Name not declared')
-            return name
+            return expr['word']
         elif expr['type'] in ('integer', 'string'):
             return expr['type'].upper()
         else:
@@ -22,6 +19,8 @@ def resolve(expr, frame):
     if oper is get:
         expr['left'] = frame
         name = resolve(expr['right'], frame)
+        if name not in frame:
+            raise LogicError(f'{name}: Name not declared')
         return frame[name]['type']
     elif oper in (lt, lte, gt, gte, ne, eq):
         return 'BOOLEAN'


### PR DESCRIPTION
# Static typing

9608 pseudocode is a **statically typed** language. Notice that when declaring variables, we declare their type as well. And the pseudocode operators and functions expect specific types in most cases:
- the arithmetic operators expect only numeric types
- the comparison operators expect numeric types and always return a boolean
- (somewhat annoyingly) you cannot assign a value to a variable if the value type is different from the variable's declared type.

Static typing implies that the value and variable types should be known at compile time. This means that before we step into `interpret()`, the interpreter should already know what it is dealing with, and be reasonably sure it can execute statements safely in most cases.

In other words, we shouldn't be seeing much type-checking code like

```
    if frametype == 'INTEGER' and valuetype != int:
        raise LogicError(f'Expected {frametype}, got {valuetype}')
    elif frametype == 'REAL' and valuetype != float:
        raise LogicError(f'Expected {frametype}, got {valuetype}')
    elif frametype == 'STRING' and valuetype != str:
        raise LogicError(f'Expected {frametype}, got {valuetype}')
```

It is telling that this is a `LogicError`: it could have been checked before we attempted `interpret()`ing.

It sure seems like this is a job our resolver should take on while it is inserting `frame`s into `get`s; it feels right, too, that as it inserts frames it also checks types.