### PR TITLE
12b Procedure calls

### DIFF
--- a/interpreter.py
+++ b/interpreter.py
@@ -2,7 +2,7 @@ from builtin import RuntimeError
 
 
 
-def evaluate(expr, frame=None):
+def evaluate(frame, expr):
     # Evaluating tokens
     if 'type' in expr:
         if expr['type'] == 'name':
@@ -13,36 +13,36 @@ def evaluate(expr, frame=None):
         return expr
     # Evaluating exprs
     oper = expr['oper']['value']
-    left = evaluate(expr['left'])
-    right = evaluate(expr['right'])
+    left = evaluate(frame, expr['left'])
+    right = evaluate(frame, expr['right'])
     return oper(left, right)
 
 def execOutput(frame, stmt):
     for expr in stmt['exprs']:
-        print(str(evaluate(expr, frame)), end='')
+        print(str(evaluate(frame, expr)), end='')
     print('')  # Add \n
 
 def execInput(frame, stmt):
-    name = evaluate(stmt['name'], frame)
+    name = evaluate(frame, stmt['name'])
     frame[name]['value'] = input()
 
 def execDeclare(frame, stmt):
     pass
 
 def execAssign(frame, stmt):
-    name = evaluate(stmt['name'], frame)
-    value = evaluate(stmt['expr'], frame)
+    name = evaluate(frame, stmt['name'])
+    value = evaluate(frame, stmt['expr'])
     frame[name]['value'] = value
 
 def execCase(frame, stmt):
-    cond = evaluate(stmt['cond'], frame)
+    cond = evaluate(frame, stmt['cond'])
     if cond in stmt['stmts']:
         execute(frame, stmt['stmts'][cond])
     elif stmt['fallback']:
         execute(frame, stmt['fallback'])
 
 def execIf(frame, stmt):
-    if evaluate(stmt['cond'], frame):
+    if evaluate(frame, stmt['cond']):
         for substmt in stmt['stmts'][True]:
             execute(frame, substmt)
     elif stmt['fallback']:
@@ -52,14 +52,14 @@ def execIf(frame, stmt):
 def execWhile(frame, stmt):
     if stmt['init']:
         execute(frame, stmt['init'])
-    while evaluate(stmt['cond'], frame) is True:
+    while evaluate(frame, stmt['cond']) is True:
         for loopstmt in stmt['stmts']:
             execute(frame, loopstmt)
 
 def execRepeat(frame, stmt):
     for loopstmt in stmt['stmts']:
         execute(frame, loopstmt)
-    while evaluate(stmt['cond'], frame) is False:
+    while evaluate(frame, stmt['cond']) is False:
         for loopstmt in stmt['stmts']:
             execute(frame, loopstmt)
 
@@ -68,11 +68,11 @@ def execProcedure(frame, stmt):
 
 def execCall(frame, stmt):
     # Get procedure from frame
-    proc = evaluate(stmt['name'], frame)
+    proc = evaluate(frame, stmt['name'])
     # Assign args into frame with param names
     args, params = stmt['args'], proc['params']
     for arg, var, param in zip(args, params.keys(), params.values()):
-        frame[var]['value'] = evaluate(arg, frame)
+        frame[var]['value'] = evaluate(frame, arg)
     for callstmt in proc['stmts']:
         execute(frame, callstmt)
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -69,7 +69,7 @@ def execProcedure(frame, stmt):
     name = evaluate(stmt['name'], frame)
     frame[name] = {
         'type': 'procedure',
-        'args': stmt['args'],
+        'params': stmt['params'],
         'stmts': stmt['stmts'],
     }
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -66,6 +66,16 @@ def execRepeat(frame, stmt):
 def execProcedure(frame, stmt):
     pass
 
+def execCall(frame, stmt):
+    # Get procedure from frame
+    proc = evaluate(stmt['name'], frame)
+    # Assign args into frame with param names
+    args, params = stmt['args'], proc['params']
+    for arg, var, param in zip(args, params.keys(), params.values()):
+        frame[var]['value'] = evaluate(frame, arg)
+    for callstmt in proc['stmts']:
+        execute(frame, callstmt)
+
 def execute(frame, stmt):
     if stmt['rule'] == 'output':
         execOutput(frame, stmt)
@@ -85,6 +95,8 @@ def execute(frame, stmt):
         execRepeat(frame, stmt)
     if stmt['rule'] == 'procedure':
         execProcedure(frame, stmt)
+    if stmt['rule'] == 'call':
+        execCall(frame, stmt)
 
 def interpret(statements, frame=None):
     if frame is None:

--- a/interpreter.py
+++ b/interpreter.py
@@ -72,7 +72,7 @@ def execCall(frame, stmt):
     # Assign args into frame with param names
     args, params = stmt['args'], proc['params']
     for arg, var, param in zip(args, params.keys(), params.values()):
-        frame[var]['value'] = evaluate(frame, arg)
+        frame[var]['value'] = evaluate(arg, frame)
     for callstmt in proc['stmts']:
         execute(frame, callstmt)
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -27,9 +27,7 @@ def execInput(frame, stmt):
     frame[name]['value'] = input()
 
 def execDeclare(frame, stmt):
-    name = evaluate(stmt['name'], frame)
-    type_ = evaluate(stmt['type'], frame)
-    frame[name] = {'type': type_, 'value': None}
+    pass
 
 def execAssign(frame, stmt):
     name = evaluate(stmt['name'], frame)
@@ -66,12 +64,7 @@ def execRepeat(frame, stmt):
             execute(frame, loopstmt)
 
 def execProcedure(frame, stmt):
-    name = evaluate(stmt['name'], frame)
-    frame[name] = {
-        'type': 'procedure',
-        'params': stmt['params'],
-        'stmts': stmt['stmts'],
-    }
+    pass
 
 def execute(frame, stmt):
     if stmt['rule'] == 'output':

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ DECLARE Person : STRING
 PROCEDURE SayHi(Person : STRING)
     OUTPUT "Hi, ", Person, "!"
 ENDPROCEDURE
+CALL SayHi("John")
 '''
 
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import sys
+from pprint import PrettyPrinter
 
 from builtin import ParseError, RuntimeError, LogicError
 import scanner
@@ -19,6 +20,7 @@ CALL SayHi("John")
 
 
 def main():
+    pp = PrettyPrinter(indent=2, compact=True)
     try:
         tokens = scanner.scan(src)
         statements = parser.parse(tokens)
@@ -28,7 +30,7 @@ def main():
         sys.exit(65)
     try:
         frame = interpreter.interpret(statements, frame)
-        print(frame)
+        pp.pprint(frame)
     except RuntimeError as err:
         print(err)
         sys.exit(70)

--- a/parser.py
+++ b/parser.py
@@ -297,8 +297,10 @@ def procedureStmt(tokens):
     if match(tokens, '('):
         var = identifier(tokens)
         expectElseError(tokens, ':')
-        typetoken = consume(tokens)
-        params[var['word']] = {'type': typetoken, 'value': None}
+        type_ = consume(tokens)['word']
+        if type_ not in TYPES:
+            raise ParseError('Invalid param type {repr(type_)}')
+        params[var['word']] = {'type': type_, 'value': None}
         while match(tokens, ','):
             var = identifier(tokens)
             expectElseError(tokens, ':')

--- a/parser.py
+++ b/parser.py
@@ -291,17 +291,17 @@ def forStmt(tokens):
 
 def procedureStmt(tokens):
     name = identifier(tokens)
-    args = {}
+    params = {}
     if match(tokens, '('):
         var = identifier(tokens)
         expectElseError(tokens, ':')
         typetoken = consume(tokens)
-        args[var['word']] = {'type': typetoken, 'value': None}
+        params[var['word']] = {'type': typetoken, 'value': None}
         while match(tokens, ','):
             var = identifier(tokens)
             expectElseError(tokens, ':')
             typetoken = consume(tokens)
-            args[var['word']] = {'type': typetoken, 'value': None}
+            params[var['word']] = {'type': typetoken, 'value': None}
         expectElseError(tokens, ')')
     expectElseError(tokens, '\n')
     stmts = []
@@ -312,7 +312,7 @@ def procedureStmt(tokens):
     stmt = {
         'rule': 'procedure',
         'name': name,
-        'args': args,
+        'params': params,
         'stmts': stmts,
     }
     return stmt

--- a/parser.py
+++ b/parser.py
@@ -317,6 +317,24 @@ def procedureStmt(tokens):
     }
     return stmt
 
+def callStmt(tokens):
+    name = identifier(tokens)
+    args = []
+    if match(tokens, '('):
+        arg = expression(tokens)
+        args += [arg]
+        while match(tokens, ','):
+            arg = expression(tokens)
+            args += [arg]
+        expectElseError(tokens, ')')
+    expectElseError(tokens, '\n')
+    stmt = {
+        'rule': 'call',
+        'name': name,
+        'args': args,
+    }
+    return stmt
+
 def statement(tokens):
     if match(tokens, 'OUTPUT'):
         return outputStmt(tokens)
@@ -336,6 +354,8 @@ def statement(tokens):
         return forStmt(tokens)
     if match(tokens, 'PROCEDURE'):
         return procedureStmt(tokens)
+    if match(tokens, 'CALL'):
+        return callStmt(tokens)
     elif check(tokens)['type'] == 'name':
         return assignStmt(tokens)
     else:

--- a/parser.py
+++ b/parser.py
@@ -1,4 +1,6 @@
-from builtin import ParseError, get, lte, add
+from builtin import TYPES
+from builtin import ParseError
+from builtin import get, lte, add
 from scanner import makeToken
 
 

--- a/parser.py
+++ b/parser.py
@@ -318,7 +318,7 @@ def procedureStmt(tokens):
     return stmt
 
 def callStmt(tokens):
-    name = identifier(tokens)
+    name = value(tokens)
     args = []
     if match(tokens, '('):
         arg = expression(tokens)

--- a/resolver.py
+++ b/resolver.py
@@ -86,6 +86,12 @@ def verifyWhile(frame, stmt):
 def verifyProcedure(frame, stmt):
     for procstmt in stmt['stmts']:
         verify(frame, procstmt)
+    name = resolve(stmt['name'])
+    frame[name] = {
+        'type': 'procedure',
+        'params': stmt['params'],
+        'stmts': stmt['stmts'],
+    }
 
 def verifyCall(frame, stmt):
     # Type-check procedure

--- a/resolver.py
+++ b/resolver.py
@@ -107,9 +107,11 @@ def verifyCall(frame, stmt):
     for arg, name, param in zip(args, params.keys(), params.values()):
         # Insert frame
         argtype = resolve(frame, arg)
+        paramtype = resolve(frame, param['type'])
+        breakpoint()
         # Type-check args against param types
-        if argtype != param['type']:
-            raise LogicError(f"Expect {param['type']} for {name}, got {argtype}")
+        if argtype != paramtype:
+            raise LogicError(f"Expect {paramtype} for {name}, got {argtype}")
 
 def verify(frame, stmt):
     if 'rule' not in stmt: breakpoint()

--- a/resolver.py
+++ b/resolver.py
@@ -95,6 +95,8 @@ def verifyProcedure(frame, stmt):
 
 def verifyCall(frame, stmt):
     # Type-check procedure
+    # Insert frame
+    stmt['name']['left'] = frame
     # resolve() would return the expr type, but we need the name
     name = resolve(frame, stmt['name']['right'])
     proc = frame[name]

--- a/resolver.py
+++ b/resolver.py
@@ -108,7 +108,6 @@ def verifyCall(frame, stmt):
         # Insert frame
         argtype = resolve(frame, arg)
         paramtype = resolve(frame, param['type'])
-        breakpoint()
         # Type-check args against param types
         if argtype != paramtype:
             raise LogicError(f"Expect {paramtype} for {name}, got {argtype}")

--- a/resolver.py
+++ b/resolver.py
@@ -89,8 +89,10 @@ def verifyProcedure(frame, stmt):
     name = resolve(frame, stmt['name'])
     frame[name] = {
         'type': 'procedure',
-        'params': stmt['params'],
-        'stmts': stmt['stmts'],
+        'value': {
+            'params': stmt['params'],
+            'stmts': stmt['stmts'],
+        }
     }
 
 def verifyCall(frame, stmt):

--- a/resolver.py
+++ b/resolver.py
@@ -87,6 +87,13 @@ def verifyProcedure(frame, stmt):
     for procstmt in stmt['stmts']:
         verify(frame, procstmt)
 
+def verifyCall(frame, stmt):
+    # Insert frame for get exprs (procedure, args)
+    # Type-check called procedure
+    # Type-check args against param types
+    # Verify statements
+    pass
+
 def verify(frame, stmt):
     if 'rule' not in stmt: breakpoint()
     if stmt['rule'] == 'output':
@@ -103,6 +110,8 @@ def verify(frame, stmt):
         verifyIf(frame, stmt)
     elif stmt['rule'] == 'procedure':
         verifyProcedure(frame, stmt)
+    elif stmt['rule'] == 'call':
+        verifyCall(frame, stmt)
     elif stmt['rule'] in ('while', 'repeat'):
         verifyWhile(frame, stmt)
 

--- a/resolver.py
+++ b/resolver.py
@@ -88,11 +88,20 @@ def verifyProcedure(frame, stmt):
         verify(frame, procstmt)
 
 def verifyCall(frame, stmt):
-    # Insert frame for get exprs (procedure, args)
-    # Type-check called procedure
-    # Type-check args against param types
-    # Verify statements
-    pass
+    # Type-check procedure
+    proc = frame[stmt['name']]
+    if proc['type'] != 'procedure':
+        raise LogicError(f"CALL {proc['name']} is not a procedure")
+    params = proc['params']
+    args = stmt['args']
+    if len(args) != len(params):
+        raise LogicError(f'Expected {len(params)} args, got {len(args)}')
+    for arg, name, param in zip(args, params.keys(), params.values()):
+        # Insert frame
+        argtype = resolve(frame, arg)
+        # Type-check args against param types
+        if argtype != param['type']:
+            raise LogicError(f"Expect {param['type']} for {name}, got {argtype}")
 
 def verify(frame, stmt):
     if 'rule' not in stmt: breakpoint()

--- a/resolver.py
+++ b/resolver.py
@@ -107,10 +107,9 @@ def verifyCall(frame, stmt):
     for arg, name, param in zip(args, params.keys(), params.values()):
         # Insert frame
         argtype = resolve(frame, arg)
-        paramtype = resolve(frame, param['type'])
         # Type-check args against param types
-        if argtype != paramtype:
-            raise LogicError(f"Expect {paramtype} for {name}, got {argtype}")
+        if argtype != param['type']:
+            raise LogicError(f"Expect {param['type']} for {name}, got {argtype}")
 
 def verify(frame, stmt):
     if 'rule' not in stmt: breakpoint()

--- a/resolver.py
+++ b/resolver.py
@@ -86,7 +86,7 @@ def verifyWhile(frame, stmt):
 def verifyProcedure(frame, stmt):
     for procstmt in stmt['stmts']:
         verify(frame, procstmt)
-    name = resolve(stmt['name'])
+    name = resolve(frame, stmt['name'])
     frame[name] = {
         'type': 'procedure',
         'params': stmt['params'],
@@ -95,7 +95,9 @@ def verifyProcedure(frame, stmt):
 
 def verifyCall(frame, stmt):
     # Type-check procedure
-    proc = frame[stmt['name']]
+    # resolve() would return the expr type, but we need the name
+    name = resolve(frame, stmt['name']['right'])
+    proc = frame[name]
     if proc['type'] != 'procedure':
         raise LogicError(f"CALL {proc['name']} is not a procedure")
     params = proc['params']

--- a/resolver.py
+++ b/resolver.py
@@ -104,7 +104,7 @@ def verifyCall(frame, stmt):
     proc = frame[name]
     if proc['type'] != 'procedure':
         raise LogicError(f"CALL {proc['name']} is not a procedure")
-    params = proc['params']
+    params = proc['value']['params']
     args = stmt['args']
     if len(args) != len(params):
         raise LogicError(f'Expected {len(params)} args, got {len(args)}')


### PR DESCRIPTION
Now we figure out how to call procedures and execute those stored statements.

First, let's rectify an unfortunate choice of term: when defining procedures, we declare **parameters** not arguments; we will later call the procedure and *pass arguments*.

[c47a42abe24bc608ab3ceeb7c0b96310f755f9f8]