### PR TITLE
12c Passing by reference

### DIFF
--- a/interpreter.py
+++ b/interpreter.py
@@ -67,14 +67,18 @@ def execProcedure(frame, stmt):
     pass
 
 def execCall(frame, stmt):
+    # Set up local frame
+    local = {}
+    for var, typevalue in frame.items():
+        local[var] = typevalue.copy()
     # Get procedure from frame
     proc = evaluate(frame, stmt['name'])
-    # Assign args into frame with param names
+    # Assign args into local with param names
     args, params = stmt['args'], proc['params']
     for arg, var, param in zip(args, params.keys(), params.values()):
-        frame[var]['value'] = evaluate(frame, arg)
+        local[var]['value'] = evaluate(frame, arg)
     for callstmt in proc['stmts']:
-        execute(frame, callstmt)
+        execute(local, callstmt)
 
 def execute(frame, stmt):
     if stmt['rule'] == 'output':

--- a/interpreter.py
+++ b/interpreter.py
@@ -71,6 +71,7 @@ def execCall(frame, stmt):
     #     'type': 'procedure',
     #     'value': {
     #         'frame': local,
+    #         'passby': stmt['passby']['word'],
     #         'params': stmt['params'],
     #         'stmts': stmt['stmts'],
     #     }
@@ -78,11 +79,12 @@ def execCall(frame, stmt):
     # Get procedure from frame
     proc = evaluate(frame, stmt['name'])
     # Set up local frame
-    local = proc['value']['frame'].copy()
+    local = {name: var for name, var in proc['frame'].items()}
     # Assign args into local with param names
-    args, params = stmt['args'], proc['value']['params']
+    args, params = stmt['args'], proc['params']
     for arg, param in zip(args, params):
-        local[param['name']]['value'] = evaluate(frame, arg)
+        name = evaluate(local, param['name'])
+        local[name]['value'] = evaluate(frame, arg)
     for callstmt in proc['stmts']:
         execute(local, callstmt)
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -67,16 +67,22 @@ def execProcedure(frame, stmt):
     pass
 
 def execCall(frame, stmt):
-    # Set up local frame
-    local = {}
-    for var, typevalue in frame.items():
-        local[var] = typevalue.copy()
+    # frame[name] = {
+    #     'type': 'procedure',
+    #     'value': {
+    #         'frame': local,
+    #         'params': stmt['params'],
+    #         'stmts': stmt['stmts'],
+    #     }
+    # }
     # Get procedure from frame
     proc = evaluate(frame, stmt['name'])
+    # Set up local frame
+    local = proc['value']['frame'].copy()
     # Assign args into local with param names
-    args, params = stmt['args'], proc['params']
-    for arg, var, param in zip(args, params.keys(), params.values()):
-        local[var]['value'] = evaluate(frame, arg)
+    args, params = stmt['args'], proc['value']['params']
+    for arg, param in zip(args, params):
+        local[param['name']]['value'] = evaluate(frame, arg)
     for callstmt in proc['stmts']:
         execute(local, callstmt)
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -71,15 +71,19 @@ def execCall(frame, stmt):
     #     'type': 'procedure',
     #     'value': {
     #         'frame': local,
-    #         'passby': stmt['passby']['word'],
+    #         'passby': str,
     #         'params': stmt['params'],
     #         'stmts': stmt['stmts'],
     #     }
     # }
     # Get procedure from frame
     proc = evaluate(frame, stmt['name'])
-    # Set up local frame
-    local = {name: var for name, var in proc['frame'].items()}
+    # Note: for BYREF variables, the procedure's frame
+    # may still contain values from previous calls.
+    # Do not evaluate any get exprs for local frame
+    # before assigning local variables from args.
+    local = proc['frame']
+    
     # Assign args into local with param names
     args, params = stmt['args'], proc['params']
     for arg, param in zip(args, params):

--- a/main.py
+++ b/main.py
@@ -13,8 +13,10 @@ src = '''
 DECLARE Person : STRING
 PROCEDURE SayHi(BYREF Person : STRING)
     OUTPUT "Hi, ", Person, "!"
+    Person <- "Mary"
 ENDPROCEDURE
 CALL SayHi("John")
+OUTPUT Person
 '''
 
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import interpreter
 
 src = '''
 DECLARE Person : STRING
-PROCEDURE SayHi(Person : STRING)
+PROCEDURE SayHi(BYREF Person : STRING)
     OUTPUT "Hi, ", Person, "!"
 ENDPROCEDURE
 CALL SayHi("John")

--- a/parser.py
+++ b/parser.py
@@ -133,15 +133,25 @@ def inputStmt(tokens):
     }
     return stmt
 
-def declareStmt(tokens):
+def declare(tokens):
     name = identifier(tokens)
     expectElseError(tokens, ':')
     typetoken = consume(tokens)
+    if typetoken['word'] not in TYPES:
+        raise ParseError(f"Invalid type {typetoken['word']}")
+    var = {
+        'name': name,
+        'type': typetoken,
+    }
+    return var
+    
+def declareStmt(tokens):
+    var = declare(tokens)
     expectElseError(tokens, '\n')
     stmt = {
         'rule': 'declare',
-        'name': name,
-        'type': typetoken,
+        'name': var['name'],
+        'type': var['type'],
     }
     return stmt
 

--- a/parser.py
+++ b/parser.py
@@ -303,22 +303,16 @@ def forStmt(tokens):
 
 def procedureStmt(tokens):
     name = identifier(tokens)
-    params = {}
+    params = []
     if match(tokens, '('):
         passby = {'type': 'keyword', 'word': 'BYVALUE', 'value': None}
         if match(tokens, 'BYVALUE', 'BYREF'):
             passby = consume(tokens)
-        var = identifier(tokens)
-        expectElseError(tokens, ':')
-        type_ = consume(tokens)['word']
-        if type_ not in TYPES:
-            raise ParseError('Invalid param type {repr(type_)}')
-        params[var['word']] = {'type': type_, 'value': None}
+        var = declare(tokens)
+        params += [var]
         while match(tokens, ','):
-            var = identifier(tokens)
-            expectElseError(tokens, ':')
-            typetoken = consume(tokens)
-            params[var['word']] = {'type': typetoken, 'value': None}
+            var = declare(tokens)
+            params += [var]
         expectElseError(tokens, ')')
     expectElseError(tokens, '\n')
     stmts = []

--- a/parser.py
+++ b/parser.py
@@ -306,7 +306,7 @@ def procedureStmt(tokens):
     params = []
     if match(tokens, '('):
         passby = {'type': 'keyword', 'word': 'BYVALUE', 'value': None}
-        if match(tokens, 'BYVALUE', 'BYREF'):
+        if check(tokens)['word'] in ('BYVALUE', 'BYREF'):
             passby = consume(tokens)
         var = declare(tokens)
         params += [var]

--- a/parser.py
+++ b/parser.py
@@ -295,6 +295,9 @@ def procedureStmt(tokens):
     name = identifier(tokens)
     params = {}
     if match(tokens, '('):
+        passby = {'type': 'keyword', 'word': 'BYVALUE', 'value': None}
+        if match(tokens, 'BYVALUE', 'BYREF'):
+            passby = consume(tokens)
         var = identifier(tokens)
         expectElseError(tokens, ':')
         type_ = consume(tokens)['word']
@@ -316,6 +319,7 @@ def procedureStmt(tokens):
     stmt = {
         'rule': 'procedure',
         'name': name,
+        'passby': passby,
         'params': params,
         'stmts': stmts,
     }

--- a/resolver.py
+++ b/resolver.py
@@ -108,6 +108,7 @@ def verifyProcedure(frame, stmt):
         'type': 'procedure',
         'value': {
             'frame': local,
+            'passby': stmt['passby']['word'],
             'params': stmt['params'],
             'stmts': stmt['stmts'],
         }

--- a/resolver.py
+++ b/resolver.py
@@ -94,11 +94,12 @@ def verifyProcedure(frame, stmt):
         elif passby == 'BYREF':
             name = resolve(frame, var['name'])
             globvar = frame[name]
+            vartype = resolve(frame, var['type'])
             # Type-check local against global
-            if var['type'] != globvar['type']:
+            if vartype != globvar['type']:
                 raise LogicError(
                     f"Expect {globvar['type']} for BYREF {name},"
-                    f" got {var['type']}"
+                    f" got {vartype}"
                 )
             # Reference global vars in local
             local[name] = globvar

--- a/resolver.py
+++ b/resolver.py
@@ -84,13 +84,14 @@ def verifyWhile(frame, stmt):
         verify(frame, loopstmt)
 
 def verifyProcedure(frame, stmt):
+    passby = stmt['passby']['word']
     # Set up local frame
     local = {}
     for var in stmt['params']:
         # Declare vars in local
-        if stmt['passby'] == 'BYVALUE':
+        if passby == 'BYVALUE':
             verifyDeclare(local, var)
-        elif stmt['passby'] == 'BYREF':
+        elif passby == 'BYREF':
             name = resolve(frame, var['name'])
             globvar = frame[name]
             # Type-check local against global
@@ -101,6 +102,9 @@ def verifyProcedure(frame, stmt):
                 )
             # Reference global vars in local
             local[name] = globvar
+        else:
+            # Internal error
+            raise TypeError(f"str expected for passby, got {passby}")
     # Resolve procedure statements using local
     for procstmt in stmt['stmts']:
         verify(local, procstmt)
@@ -110,7 +114,7 @@ def verifyProcedure(frame, stmt):
         'type': 'procedure',
         'value': {
             'frame': local,
-            'passby': stmt['passby']['word'],
+            'passby': passby,
             'params': stmt['params'],
             'stmts': stmt['stmts'],
         }

--- a/resolver.py
+++ b/resolver.py
@@ -107,6 +107,7 @@ def verifyProcedure(frame, stmt):
     frame[name] = {
         'type': 'procedure',
         'value': {
+            'frame': local,
             'params': stmt['params'],
             'stmts': stmt['stmts'],
         }

--- a/resolver.py
+++ b/resolver.py
@@ -114,24 +114,25 @@ def verifyProcedure(frame, stmt):
     }
 
 def verifyCall(frame, stmt):
-    # Type-check procedure
     # Insert frame
     stmt['name']['left'] = frame
     # resolve() would return the expr type, but we need the name
     name = resolve(frame, stmt['name']['right'])
     proc = frame[name]
+    # Type-check procedure
     if proc['type'] != 'procedure':
         raise LogicError(f"CALL {proc['name']} is not a procedure")
-    params = proc['value']['params']
-    args = stmt['args']
+    args, params = stmt['args'], proc['value']['params']
     if len(args) != len(params):
         raise LogicError(f'Expected {len(params)} args, got {len(args)}')
-    for arg, name, param in zip(args, params.keys(), params.values()):
-        # Insert frame
+    # Type-check arguments
+    local = proc['value']['frame']
+    for arg, param in zip(args, params):
         argtype = resolve(frame, arg)
+        paramtype = resolve(local, param['type'])
         # Type-check args against param types
-        if argtype != param['type']:
-            raise LogicError(f"Expect {param['type']} for {name}, got {argtype}")
+        if argtype != paramtype:
+            raise LogicError(f"Expect {paramtype} for {name}, got {argtype}")
 
 def verify(frame, stmt):
     if 'rule' not in stmt: breakpoint()


### PR DESCRIPTION
9608 pseudocode recognises the notion of passing-by-value vs passing-by-reference.

Procedures are able to access all variables in the global frame. But reassigning variables is another matter.
- Passing-by-reference means that any reassignments to a variable in the local frame affect the global frame as well.
- Passing-by-value means that reassignments to a variable in the local frame do not affect the global frame. These reassignments are therefore lost when the procedure exits and the local frame is no longer used (since 9608 pseudocode does not support closures).