### PR TITLE
13a Functions

### DIFF
--- a/builtin.py
+++ b/builtin.py
@@ -43,6 +43,9 @@ def eq(x, y):
 def get(frame, name):
     return frame[name]['value']
 
+def call(func, args):
+    return func, args
+
 
 
 # Token types

--- a/interpreter.py
+++ b/interpreter.py
@@ -1,3 +1,4 @@
+from builtin import call
 from builtin import RuntimeError
 
 
@@ -13,6 +14,12 @@ def evaluate(frame, expr):
         return expr
     # Evaluating exprs
     oper = expr['oper']['value']
+    if oper is call:
+        left = evaluate(frame, expr['left'])
+        right = expr['right']
+        func, args = oper(left, right)
+        # ...
+        # return result
     left = evaluate(frame, expr['left'])
     right = evaluate(frame, expr['right'])
     return oper(left, right)

--- a/interpreter.py
+++ b/interpreter.py
@@ -18,8 +18,19 @@ def evaluate(frame, expr):
         left = evaluate(frame, expr['left'])
         right = expr['right']
         func, args = oper(left, right)
-        # ...
-        # return result
+            # 'frame': local,
+            # 'passby': 'BYVALUE',
+            # 'params': stmt['params'],
+            # 'stmts': stmt['stmts'],
+        local = func['frame']
+        # Assign args into local with param names
+        for arg, param in zip(args, func['params']):
+            name = evaluate(local, param['name'])
+            local[name]['value'] = evaluate(frame, arg)
+        for funcstmt in func['stmts']:
+            returnval = execute(local, funcstmt)
+            if returnval:
+                return returnval
     left = evaluate(frame, expr['left'])
     right = evaluate(frame, expr['right'])
     return oper(left, right)

--- a/interpreter.py
+++ b/interpreter.py
@@ -144,7 +144,7 @@ def execute(frame, stmt):
     if stmt['rule'] == 'call':
         execCall(frame, stmt)
     if stmt['rule'] == 'return':
-        execReturn(frame, stmt)
+        return execReturn(frame, stmt)
 
 def interpret(statements, frame=None):
     if frame is None:

--- a/interpreter.py
+++ b/interpreter.py
@@ -66,6 +66,9 @@ def execRepeat(frame, stmt):
 def execProcedure(frame, stmt):
     pass
 
+def execFunction(frame, stmt):
+    pass
+
 def execCall(frame, stmt):
     # frame[name] = {
     #     'type': 'procedure',
@@ -111,6 +114,8 @@ def execute(frame, stmt):
         execRepeat(frame, stmt)
     if stmt['rule'] == 'procedure':
         execProcedure(frame, stmt)
+    if stmt['rule'] == 'function':
+        execFunction(frame, stmt)
     if stmt['rule'] == 'call':
         execCall(frame, stmt)
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -18,10 +18,6 @@ def evaluate(frame, expr):
         left = evaluate(frame, expr['left'])
         right = expr['right']
         func, args = oper(left, right)
-            # 'frame': local,
-            # 'passby': 'BYVALUE',
-            # 'params': stmt['params'],
-            # 'stmts': stmt['stmts'],
         local = func['frame']
         # Assign args into local with param names
         for arg, param in zip(args, func['params']):
@@ -88,15 +84,6 @@ def execFunction(frame, stmt):
     pass
 
 def execCall(frame, stmt):
-    # frame[name] = {
-    #     'type': 'procedure',
-    #     'value': {
-    #         'frame': local,
-    #         'passby': str,
-    #         'params': stmt['params'],
-    #         'stmts': stmt['stmts'],
-    #     }
-    # }
     # Get procedure from frame
     proc = evaluate(frame, stmt['name'])
     # Note: for BYREF variables, the procedure's frame
@@ -119,7 +106,6 @@ def execReturn(local, stmt):
     # to be local
     return evaluate(local, stmt['expr'])
 
-
 def execute(frame, stmt):
     if stmt['rule'] == 'output':
         execOutput(frame, stmt)
@@ -139,10 +125,10 @@ def execute(frame, stmt):
         execRepeat(frame, stmt)
     if stmt['rule'] == 'procedure':
         execProcedure(frame, stmt)
-    if stmt['rule'] == 'function':
-        execFunction(frame, stmt)
     if stmt['rule'] == 'call':
         execCall(frame, stmt)
+    if stmt['rule'] == 'function':
+        execFunction(frame, stmt)
     if stmt['rule'] == 'return':
         return execReturn(frame, stmt)
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -113,6 +113,13 @@ def execCall(frame, stmt):
     for callstmt in proc['stmts']:
         execute(local, callstmt)
 
+def execReturn(local, stmt):
+    # This will typically be execute()ed within
+    # evaluate() in a function call, so frame is expected
+    # to be local
+    return evaluate(local, stmt['expr'])
+
+
 def execute(frame, stmt):
     if stmt['rule'] == 'output':
         execOutput(frame, stmt)
@@ -136,6 +143,8 @@ def execute(frame, stmt):
         execFunction(frame, stmt)
     if stmt['rule'] == 'call':
         execCall(frame, stmt)
+    if stmt['rule'] == 'return':
+        execReturn(frame, stmt)
 
 def interpret(statements, frame=None):
     if frame is None:

--- a/main.py
+++ b/main.py
@@ -10,13 +10,12 @@ import interpreter
 
 
 src = '''
-DECLARE Person : STRING
-PROCEDURE SayHi(BYREF Person : STRING)
-    OUTPUT "Hi, ", Person, "!"
-    Person <- "Mary"
-ENDPROCEDURE
-CALL SayHi("John")
-OUTPUT Person
+DECLARE Five : INTEGER
+FUNCTION AddOne(Num : INTEGER) RETURNS INTEGER
+    RETURN Num + 1
+ENDFUNCTION
+Five <- 5
+OUTPUT "5 + 1 is ", AddOne(Five)
 '''
 
 

--- a/parser.py
+++ b/parser.py
@@ -1,6 +1,6 @@
 from builtin import TYPES
 from builtin import ParseError
-from builtin import get, lte, add
+from builtin import get, lte, add, call
 from scanner import makeToken
 
 
@@ -64,6 +64,7 @@ def value(tokens):
                 arg = expression(tokens)
                 args += [arg]
             expectElseError(tokens, ')')
+            expr = makeExpr(expr, call, args)
         return expr
     else:
         raise ParseError(f"Unexpected token {repr(token['word'])}")

--- a/parser.py
+++ b/parser.py
@@ -378,6 +378,15 @@ def functionStmt(tokens):
     }
     return stmt
 
+def returnStmt(tokens):
+    expr = expression(tokens)
+    expectElseError(tokens, '\n')
+    stmt = {
+        'rule': 'return',
+        'expr': expr,
+    }
+    return stmt
+
 def statement(tokens):
     if match(tokens, 'OUTPUT'):
         return outputStmt(tokens)
@@ -401,6 +410,8 @@ def statement(tokens):
         return callStmt(tokens)
     if match(tokens, 'FUNCTION'):
         return functionStmt(tokens)
+    if match(tokens, 'RETURN'):
+        return returnStmt(tokens)
     elif check(tokens)['type'] == 'name':
         return assignStmt(tokens)
     else:

--- a/parser.py
+++ b/parser.py
@@ -55,14 +55,16 @@ def value(tokens):
         name = identifier(tokens)
         oper = {'type': 'symbol', 'word': '', 'value': get}
         args = []
+        expr = makeExpr(frame, oper, name)
+        # Function call
         if match(tokens, '('):
             arg = expression(tokens)
             args += [arg]
             while match(tokens, ','):
                 arg = expression(tokens)
                 args += [arg]
-        expectElseError(tokens, ')')
-        return makeExpr(frame, oper, name)
+            expectElseError(tokens, ')')
+        return expr
     else:
         raise ParseError(f"Unexpected token {repr(token['word'])}")
 

--- a/parser.py
+++ b/parser.py
@@ -374,6 +374,7 @@ def functionStmt(tokens):
         'passby': passby,
         'params': params,
         'stmts': stmts,
+        'returns': typetoken,
     }
     return stmt
 

--- a/parser.py
+++ b/parser.py
@@ -347,6 +347,36 @@ def callStmt(tokens):
     }
     return stmt
 
+def functionStmt(tokens):
+    name = identifier(tokens)
+    params = []
+    if match(tokens, '('):
+        passby = {'type': 'keyword', 'word': 'BYVALUE', 'value': None}
+        var = declare(tokens)
+        params += [var]
+        while match(tokens, ','):
+            var = declare(tokens)
+            params += [var]
+        expectElseError(tokens, ')')
+    expectElseError(tokens, 'RETURNS')
+    typetoken = consume(tokens)
+    if typetoken['word'] not in TYPES:
+        raise ParseError(f"Invalid type {typetoken['word']}")
+    expectElseError(tokens, '\n')
+    stmts = []
+    while not atEnd(tokens) and check(tokens)['word'] not in ('ENDFUNCTION',):
+        stmts += [statement(tokens)]
+    expectElseError(tokens, 'ENDFUNCTION')
+    expectElseError(tokens, '\n')
+    stmt = {
+        'rule': 'function',
+        'name': name,
+        'passby': passby,
+        'params': params,
+        'stmts': stmts,
+    }
+    return stmt
+
 def statement(tokens):
     if match(tokens, 'OUTPUT'):
         return outputStmt(tokens)
@@ -368,6 +398,8 @@ def statement(tokens):
         return procedureStmt(tokens)
     if match(tokens, 'CALL'):
         return callStmt(tokens)
+    if match(tokens, 'FUNCTION'):
+        return functionStmt(tokens)
     elif check(tokens)['type'] == 'name':
         return assignStmt(tokens)
     else:

--- a/parser.py
+++ b/parser.py
@@ -54,6 +54,14 @@ def value(tokens):
         frame = None
         name = identifier(tokens)
         oper = {'type': 'symbol', 'word': '', 'value': get}
+        args = []
+        if match(tokens, '('):
+            arg = expression(tokens)
+            args += [arg]
+            while match(tokens, ','):
+                arg = expression(tokens)
+                args += [arg]
+        expectElseError(tokens, ')')
         return makeExpr(frame, oper, name)
     else:
         raise ParseError(f"Unexpected token {repr(token['word'])}")
@@ -103,7 +111,7 @@ def expectElseError(tokens, word):
     if check(tokens)['word'] == word:
         consume(tokens)
         return True
-    raise ParseError(f"Expected {word}")
+    raise ParseError(fr"Expected {word}")
 
 def match(tokens, *words):
     if check(tokens)['word'] in words:

--- a/parser.py
+++ b/parser.py
@@ -64,7 +64,8 @@ def value(tokens):
                 arg = expression(tokens)
                 args += [arg]
             expectElseError(tokens, ')')
-            expr = makeExpr(expr, call, args)
+            oper = {'type': 'symbol', 'word': '', 'value': call}
+            expr = makeExpr(expr, oper, args)
         return expr
     else:
         raise ParseError(f"Unexpected token {repr(token['word'])}")

--- a/resolver.py
+++ b/resolver.py
@@ -159,10 +159,9 @@ def verifyFunction(frame, stmt):
     returns = resolve(frame, stmt['returns'])
     for procstmt in stmt['stmts']:
         returntype = verify(local, procstmt)
-        breakpoint()
         if returntype and (returntype != returns):
             raise LogicError(f"Expect {returns} for {name}, got {returntype}")
-    # Declare procedure in frame
+    # Declare function in frame
     frame[name] = {
         'type': returns,
         'value': {

--- a/resolver.py
+++ b/resolver.py
@@ -1,4 +1,4 @@
-from builtin import get
+from builtin import get, call
 from builtin import lt, lte, gt, gte, ne, eq
 from builtin import add, sub, mul, div
 from builtin import LogicError
@@ -15,8 +15,7 @@ def resolve(frame, expr):
         else:
             # internal error
             raise TypeError(f'Cannot resolve type for {expr}')
-    # Resolving gets requires special handling
-    # of expr's left and right
+    # Resolving get expressions
     oper = expr['oper']['value']
     if oper is get:
         expr['left'] = frame
@@ -24,6 +23,13 @@ def resolve(frame, expr):
         if name not in frame:
             raise LogicError(f'{name}: Name not declared')
         return frame[name]['type']
+    # Resolving function calls
+    if oper is call:
+        # Insert frame into get expr
+        resolve(frame, expr['left'])
+        # Return function type
+        functype = resolve(frame, expr['left'])
+        return functype
     # Resolving other exprs
     lefttype = resolve(frame, expr['left'])
     righttype = resolve(frame, expr['right'])

--- a/resolver.py
+++ b/resolver.py
@@ -169,6 +169,12 @@ def verifyFunction(frame, stmt):
         }
     }
 
+def verifyReturn(local, stmt):
+    # This will typically be verify()ed within
+    # verifyFunction(), so frame is expected to
+    # be local
+    return resolve(local, stmt['expr'])
+
 def verify(frame, stmt):
     if 'rule' not in stmt: breakpoint()
     if stmt['rule'] == 'output':
@@ -191,6 +197,8 @@ def verify(frame, stmt):
         verifyWhile(frame, stmt)
     elif stmt['rule'] == 'function':
         verifyFunction(frame, stmt)
+    elif stmt['rule'] == 'return':
+        verifyReturn(frame, stmt)
 
 def inspect(statements):
     frame = {}

--- a/resolver.py
+++ b/resolver.py
@@ -142,6 +142,28 @@ def verifyCall(frame, stmt):
         if argtype != paramtype:
             raise LogicError(f"Expect {paramtype} for {name}, got {argtype}")
 
+def verifyFunction(frame, stmt):
+    # Set up local frame
+    local = {}
+    for var in stmt['params']:
+        # Declare vars in local
+        verifyDeclare(local, var)
+    # Resolve procedure statements using local
+    for procstmt in stmt['stmts']:
+        verify(local, procstmt)
+    # Declare procedure in frame
+    name = resolve(frame, stmt['name'])
+    frame[name] = {
+        'type': 'function',
+        'value': {
+            'frame': local,
+            'passby': 'BYVALUE',
+            'params': stmt['params'],
+            'stmts': stmt['stmts'],
+            'returns': stmt['returns'],
+        }
+    }
+
 def verify(frame, stmt):
     if 'rule' not in stmt: breakpoint()
     if stmt['rule'] == 'output':
@@ -162,6 +184,8 @@ def verify(frame, stmt):
         verifyCall(frame, stmt)
     elif stmt['rule'] in ('while', 'repeat'):
         verifyWhile(frame, stmt)
+    elif stmt['rule'] == 'function':
+        verifyFunction(frame, stmt)
 
 def inspect(statements):
     frame = {}

--- a/resolver.py
+++ b/resolver.py
@@ -159,6 +159,7 @@ def verifyFunction(frame, stmt):
     returns = resolve(frame, stmt['returns'])
     for procstmt in stmt['stmts']:
         returntype = verify(local, procstmt)
+        breakpoint()
         if returntype and (returntype != returns):
             raise LogicError(f"Expect {returns} for {name}, got {returntype}")
     # Declare procedure in frame
@@ -201,7 +202,7 @@ def verify(frame, stmt):
     elif stmt['rule'] == 'function':
         verifyFunction(frame, stmt)
     elif stmt['rule'] == 'return':
-        verifyReturn(frame, stmt)
+        return verifyReturn(frame, stmt)
 
 def inspect(statements):
     frame = {}

--- a/resolver.py
+++ b/resolver.py
@@ -27,6 +27,10 @@ def resolve(frame, expr):
     if oper is call:
         # Insert frame into get expr
         resolve(frame, expr['left'])
+        # Insert frame into args
+        args = expr['right']
+        for arg in args:
+            resolve(frame, arg)
         # Return function type
         functype = resolve(frame, expr['left'])
         return functype

--- a/resolver.py
+++ b/resolver.py
@@ -155,12 +155,15 @@ def verifyFunction(frame, stmt):
         # Declare vars in local
         verifyDeclare(local, var)
     # Resolve procedure statements using local
-    for procstmt in stmt['stmts']:
-        verify(local, procstmt)
-    # Declare procedure in frame
     name = resolve(frame, stmt['name'])
+    returns = resolve(frame, stmt['returns'])
+    for procstmt in stmt['stmts']:
+        returntype = verify(local, procstmt)
+        if returntype and (returntype != returns):
+            raise LogicError(f"Expect {returns} for {name}, got {returntype}")
+    # Declare procedure in frame
     frame[name] = {
-        'type': resolve(frame, stmt['returns']),
+        'type': returns,
         'value': {
             'frame': local,
             'passby': 'BYVALUE',

--- a/resolver.py
+++ b/resolver.py
@@ -154,13 +154,12 @@ def verifyFunction(frame, stmt):
     # Declare procedure in frame
     name = resolve(frame, stmt['name'])
     frame[name] = {
-        'type': 'function',
+        'type': resolve(frame, stmt['returns']),
         'value': {
             'frame': local,
             'passby': 'BYVALUE',
             'params': stmt['params'],
             'stmts': stmt['stmts'],
-            'returns': stmt['returns'],
         }
     }
 

--- a/resolver.py
+++ b/resolver.py
@@ -196,12 +196,12 @@ def verify(frame, stmt):
         verifyCase(frame, stmt)
     elif stmt['rule'] == 'if':
         verifyIf(frame, stmt)
+    elif stmt['rule'] in ('while', 'repeat'):
+        verifyWhile(frame, stmt)
     elif stmt['rule'] == 'procedure':
         verifyProcedure(frame, stmt)
     elif stmt['rule'] == 'call':
         verifyCall(frame, stmt)
-    elif stmt['rule'] in ('while', 'repeat'):
-        verifyWhile(frame, stmt)
     elif stmt['rule'] == 'function':
         verifyFunction(frame, stmt)
     elif stmt['rule'] == 'return':


### PR DESCRIPTION
The previous chapter, [Procedures](https://github.com/nyjc-computing/pseudo/pull/20), introduced us to many new concepts that we will need here: use of a local frame, as well as passing by value.

The 9608 pseudocode reference guide says the following for functions:

> Functions operate in a similar way to procedures, except that in addition they return a single value to the
> point at which they are called. Their definition includes the data type of the value returned.
> 
> A procedure with no parameters is defined as follows:
> ```
> FUNCTION <identifier> RETURNS <data type>
>  <statements>
> ENDFUNCTION
> ```
> A procedure with parameters is defined as follows:
> ```
> FUNCTION <identifier>(<param1>:<datatype>,<param2>:<datatype>...) RETURNS <data type>
> <statements>
> ENDFUNCTION
> ```
> 
> The keyword RETURN is used as one of the statements within the body of the function to specify the value to
be returned. Normally, this will be the last statement in the function definition.
>
> Because a function returns a value that is used when the function is called, function calls are not complete program statements. The keyword CALL should not be used when calling a function. Functions should only be called as part of an expression. When the RETURN statement is executed, the value returned replaces the function call in the expression and the expression is then evaluated.
> 
> **Example – definition and use of a function**
> ```
> FUNCTION Max(Number1:INTEGER, Number2:INTEGER) RETURNS INTEGER
>     IF Number1 > Number2
>       THEN
>         RETURN Number1
>       ELSE
>         RETURN Number2
>     ENDIF
> ENDFUNCTION
> OUTPUT "Penalty Fine = ", Max(10,Distance*2)
> ```
> 
> In principle, parameters can also be passed by value or by reference to functions and will operate in a similar way. However, it should be considered bad practice to pass parameters by reference to a function and this should be avoided. Functions should have no other side effect on the program other than to return the designated value.

What this means for us:
- We'll have to figure out how to parse a FUNCTION statement
- We'll have to implement a RETURN statement
- We'll have to type-check function returns with their declared type
- We'll have to figure out how to `evaluate()` a function as an expression with a resulting value, instead of execute()`ing it as a statement
- We'll assume function parameters can only be defined BYVALUE, and treat any attempts to define them BYREF as a `ParseError`

That's four mouthfuls to chew. One at a time.