### PR TITLE
14c Referencing source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ It is also an attempt to write a programming book in a new style. Each chapter o
 - [13a Functions](https://github.com/nyjc-computing/pseudo/pull/25)
 - [13b Loose ends](https://github.com/nyjc-computing/pseudo/pull/26)
 - [14a Reading from source](https://github.com/nyjc-computing/pseudo/pull/28)
+- [14b Line numbers](https://github.com/nyjc-computing/pseudo/pull/29)

--- a/builtin.py
+++ b/builtin.py
@@ -13,8 +13,6 @@ class PseudoError(Exception):
     def msg(self):
         return self.args[0]
 
-class ParseError(PseudoError):
-    """Custom error raised by scanner and parser."""
     def report(self):
         if type(self.token) is dict:
             token = self.token['word']
@@ -22,14 +20,14 @@ class ParseError(PseudoError):
             token = self.token
         return f"{repr(token)}: {self.msg()}"
 
+class ParseError(PseudoError):
+    """Custom error raised by scanner and parser."""
+
 class RuntimeError(PseudoError):
     """Custom error raised by interpreter."""
 
 class LogicError(PseudoError):
     """Custom error raised by resolver."""
-    def report(self):
-        token = self.token['word']
-        return f"{repr(token)}: {self.msg()}"
 
 
 

--- a/builtin.py
+++ b/builtin.py
@@ -22,10 +22,10 @@ class ParseError(PseudoError):
             token = self.token
         return f"[Line {self.line}] {repr(token)}: {self.msg()}"
 
-class RuntimeError(Exception):
+class RuntimeError(PseudoError):
     """Custom error raised by interpreter."""
 
-class LogicError(Exception):
+class LogicError(PseudoError):
     """Custom error raised by resolver."""
 
 

--- a/builtin.py
+++ b/builtin.py
@@ -27,6 +27,9 @@ class RuntimeError(PseudoError):
 
 class LogicError(PseudoError):
     """Custom error raised by resolver."""
+    def report(self):
+        token = self.token['word']
+        return f"[Line {self.line}] {repr(token)}: {self.msg()}"
 
 
 

--- a/builtin.py
+++ b/builtin.py
@@ -20,7 +20,7 @@ class ParseError(PseudoError):
             token = self.token['word']
         else:
             token = self.token
-        return f"[Line {self.line}] {repr(token)}: {self.msg()}"
+        return f"{repr(token)}: {self.msg()}"
 
 class RuntimeError(PseudoError):
     """Custom error raised by interpreter."""
@@ -29,7 +29,7 @@ class LogicError(PseudoError):
     """Custom error raised by resolver."""
     def report(self):
         token = self.token['word']
-        return f"[Line {self.line}] {repr(token)}: {self.msg()}"
+        return f"{repr(token)}: {self.msg()}"
 
 
 

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ def main():
         statements = parser.parse(tokens)
         statements, frame = resolver.inspect(statements)
     except (ParseError, LogicError) as err:
+        print(f"[Line {err.line}]", lines[err.line])
         print(err.report())
         sys.exit(65)
     try:

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ def main():
         src = f.read()
     pp = PrettyPrinter(indent=2, compact=True)
     try:
-        tokens = scanner.scan(src)
+        tokens, lines = scanner.scan(src)
         statements = parser.parse(tokens)
         statements, frame = resolver.inspect(statements)
     except (ParseError, LogicError) as err:

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def main():
         statements = parser.parse(tokens)
         statements, frame = resolver.inspect(statements)
     except (ParseError, LogicError) as err:
-        print(f"[Line {err.line}]", lines[err.line])
+        print(f"[Line {err.line}]", lines[err.line - 1])
         print(err.report())
         sys.exit(65)
     try:

--- a/parser.py
+++ b/parser.py
@@ -30,7 +30,7 @@ def expectElseError(tokens, word, addmsg=None):
     if check(tokens)['word'] == word:
         consume(tokens)
         return True
-    msg = "Expected {addmsg}" if addmsg else "Expected"
+    msg = f"Expected {addmsg}" if addmsg else "Expected"
     raise ParseError(msg, check(tokens))
 
 def match(tokens, *words):

--- a/resolver.py
+++ b/resolver.py
@@ -16,7 +16,10 @@ def expectTypeElseError(frame, expr, expected):
             token = expr['left']
         elif 'line' in expr['right']:
             token = expr['right']
-        raise LogicError(f"Expected {repr(expected)}, got {repr(exprtype)}", token)
+        raise LogicError(
+            f"Expected {repr(expected)}, got {repr(exprtype)}",
+            token,
+        )
 
 def resolveExprs(frame, exprs):
     for expr in exprs:
@@ -42,7 +45,10 @@ def resolve(frame, expr):
         expr['left'] = frame
         name = resolve(frame, expr['right'])
         if name not in frame:
-            raise LogicError(f'{name}: Name not declared', expr['right'])
+            raise LogicError(
+                f'{name}: Name not declared',
+                expr['right'],
+            )
         return frame[name]['type']
     # Resolving function calls
     if oper is call:
@@ -68,7 +74,10 @@ def verifyOutput(frame, stmt):
 def verifyInput(frame, stmt):
     name = resolve(frame, stmt['name'])
     if name not in frame:
-        raise LogicError(f'{name}: Name not declared', stmt['name'])
+        raise LogicError(
+            f'{name}: Name not declared',
+            stmt['name'],
+        )
 
 def verifyDeclare(frame, stmt):
     name = resolve(frame, stmt['name'])
@@ -136,7 +145,10 @@ def verifyCall(frame, stmt):
     proc = frame[name]
     # Type-check procedure
     if proc['type'] != 'procedure':
-        raise LogicError(f"CALL {proc['name']} is not a procedure", stmt['name']['right'])
+        raise LogicError(
+            f"CALL {proc['name']} is not a procedure",
+            stmt['name']['right'],
+        )
     args, params = stmt['args'], proc['value']['params']
     if len(args) != len(params):
         raise LogicError(f'Expected {len(params)} args, got {len(args)}', stmt['name']['right'])
@@ -147,7 +159,10 @@ def verifyCall(frame, stmt):
             # Only names allowed for BYREF arguments
             # Check for a get expr
             if arg['oper']['value'] is not get:
-                raise LogicError('BYREF arg must be a name, not expression', stmt['passby'])
+                raise LogicError(
+                    'BYREF arg must be a name, not expression',
+                    stmt['passby'],
+                )
         paramtype = resolve(local, param['type'])
         expectTypeElseError(frame, arg, paramtype)
 
@@ -163,7 +178,10 @@ def verifyFunction(frame, stmt):
     for procstmt in stmt['stmts']:
         returntype = verify(local, procstmt)
         if returntype and (returntype != returns):
-            raise LogicError(f"Expect {returns} for {name}, got {returntype}", stmt['name'])
+            raise LogicError(
+                f"Expect {returns} for {name}, got {returntype}",
+                stmt['name'],
+            )
     # Declare function in frame
     frame[name] = {
         'type': returns,

--- a/resolver.py
+++ b/resolver.py
@@ -46,7 +46,7 @@ def resolve(frame, expr):
         name = resolve(frame, expr['right'])
         if name not in frame:
             raise LogicError(
-                f'{name}: Name not declared',
+                f'Name not declared',
                 expr['right'],
             )
         return frame[name]['type']
@@ -75,7 +75,7 @@ def verifyInput(frame, stmt):
     name = resolve(frame, stmt['name'])
     if name not in frame:
         raise LogicError(
-            f'{name}: Name not declared',
+            f'Name not declared',
             stmt['name'],
         )
 
@@ -146,12 +146,15 @@ def verifyCall(frame, stmt):
     # Type-check procedure
     if proc['type'] != 'procedure':
         raise LogicError(
-            f"CALL {proc['name']} is not a procedure",
+            f"Not a procedure",
             stmt['name']['right'],
         )
     args, params = stmt['args'], proc['value']['params']
     if len(args) != len(params):
-        raise LogicError(f'Expected {len(params)} args, got {len(args)}', stmt['name']['right'])
+        raise LogicError(
+            f'Expected {len(params)} args, got {len(args)}',
+            stmt['name']['right'],
+        )
     # Type-check arguments
     local = proc['value']['frame']
     for arg, param in zip(args, params):
@@ -179,7 +182,7 @@ def verifyFunction(frame, stmt):
         returntype = verify(local, procstmt)
         if returntype and (returntype != returns):
             raise LogicError(
-                f"Expect {returns} for {name}, got {returntype}",
+                f"Expect {returns}, got {returntype}",
                 stmt['name'],
             )
     # Declare function in frame

--- a/resolver.py
+++ b/resolver.py
@@ -143,12 +143,7 @@ def verifyCall(frame, stmt):
     # resolve() would return the expr type, but we need the name
     name = resolve(frame, stmt['name']['right'])
     proc = frame[name]
-    # Type-check procedure
-    if proc['type'] != 'procedure':
-        raise LogicError(
-            f"Not a procedure",
-            stmt['name']['right'],
-        )
+    expectTypeElseError(frame, proc, 'procedure')
     args, params = stmt['args'], proc['value']['params']
     if len(args) != len(params):
         raise LogicError(

--- a/resolver.py
+++ b/resolver.py
@@ -16,7 +16,6 @@ def expectTypeElseError(frame, expr, expected):
             token = expr['left']
         elif 'line' in expr['right']:
             token = expr['right']
-        breakpoint()
         raise LogicError(f"Expected {repr(expected)}, got {repr(exprtype)}", token)
 
 def resolveExprs(frame, exprs):

--- a/scanner.py
+++ b/scanner.py
@@ -64,6 +64,8 @@ def scan(src):
         'length': len(src),
         'cursor': 0,
         'line': 1,
+        'lineStart': 0,
+        'lines': [],
     }
     tokens = []
     while not atEnd(code):
@@ -74,7 +76,10 @@ def scan(src):
         elif char == '\n':
             text = consume(code)
             token = makeToken(code['line'], 'keyword', text, None)
+            start, end = code['lineStart'], code['cursor'] - 1
+            code['lines'] += [code['src'][start:end]]
             code['line'] += 1
+            code['lineStart'] = code['cursor']
         elif char.isalpha():
             text = word(code)
             if text in KEYWORDS:
@@ -98,4 +103,4 @@ def scan(src):
                 line=code['line'],
             )
         tokens += [token]
-    return tokens
+    return tokens, code['lines']

--- a/scanner.py
+++ b/scanner.py
@@ -6,14 +6,14 @@ from builtin import KEYWORDS, TYPES, OPERATORS, SYMBOLS
 # Helper functions
 
 def atEnd(code):
-    return (len(code['src']) == 0)
+    return code['cursor'] >= code['length']
 
 def check(code):
-    return code['src'][0]
+    return code['src'][code['cursor']]
 
 def consume(code):
     char = check(code)
-    code['src'] = code['src'][1:]
+    code['cursor'] += 1
     return char
 
 def makeToken(line, tokentype, word, value):
@@ -61,6 +61,8 @@ def symbol(code):
 def scan(src):
     code = {
         'src': src + '\n',
+        'length': len(src),
+        'cursor': 0,
         'line': 1,
     }
     tokens = []

--- a/scanner.py
+++ b/scanner.py
@@ -59,8 +59,10 @@ def symbol(code):
 # Main scanning loop
 
 def scan(src):
+    if not src.endswith('\n'):
+        src = src + '\n'
     code = {
-        'src': src + '\n',
+        'src': src,
         'length': len(src),
         'cursor': 0,
         'line': 1,


### PR DESCRIPTION
Now that we have line numbers, let's see if we can get the source code to display in our error messages 😎 

That means a pretty major change in the way we parse the code: Instead of `consume()`ing the code while stripping it character by character, we want to keep it intact so we can reference it later.