### PR TITLE
16a OOP: Expressions

### DIFF
--- a/builtin.py
+++ b/builtin.py
@@ -7,8 +7,10 @@ class PseudoError(Exception):
         self.token = token
         if line is not None:
             self.line = line
-        else:
+        elif token is not None:
             self.line = token['line']
+        else:
+            self.line = None
         self.col = token['col']
 
     def msg(self):

--- a/builtin.py
+++ b/builtin.py
@@ -7,11 +7,11 @@ class PseudoError(Exception):
         self.token = token
         if line is not None:
             self.line = line
-        elif token is not None:
+        elif token:
             self.line = token['line']
         else:
             self.line = None
-        self.col = token['col']
+        self.col = token['col'] if token else None
 
     def msg(self):
         return self.args[0]

--- a/builtin.py
+++ b/builtin.py
@@ -91,6 +91,8 @@ KEYWORDS = [
 
 TYPES = ['INTEGER', 'STRING']
 
+NULL = object()
+
 OPERATORS = {
     '+': add,
     '-': sub,

--- a/lang.py
+++ b/lang.py
@@ -1,0 +1,2 @@
+class Expr:
+    pass

--- a/lang.py
+++ b/lang.py
@@ -4,7 +4,7 @@ from builtin import add, sub, mul, div
 
 
 class Expr:
-    def resolve(self):
+    def resolve(self, frame=None):
         raise NotImplementedError
 
     def evaluate(self):
@@ -51,8 +51,8 @@ class Unary(Expr):
         self.oper = oper
         self.right = right
 
-    def resolve(self, frame=None):
-        return self.right.resolve()
+    def resolve(self, frame):
+        return self.right.resolve(frame)
 
     def evaluate(self):
         return self.oper(self.right.value)

--- a/lang.py
+++ b/lang.py
@@ -8,7 +8,7 @@ class Expr:
     def resolve(self, frame=None):
         raise NotImplementedError
 
-    def evaluate(self):
+    def evaluate(self, frame=None):
         raise NotImplementedError
 
     def __repr__(self):
@@ -28,7 +28,7 @@ class Literal(Expr):
     def resolve(self, frame=None):
         return self.type
 
-    def evaluate(self):
+    def evaluate(self, frame=None):
         return self.value
 
 
@@ -41,7 +41,7 @@ class Name(Expr):
     def resolve(self, frame=None):
         return self.name
 
-    def evaluate(self):
+    def evaluate(self, frame=None):
         return self.name
 
 
@@ -55,8 +55,8 @@ class Unary(Expr):
     def resolve(self, frame):
         return self.right.resolve(frame)
 
-    def evaluate(self):
-        right = self.right.evaluate()
+    def evaluate(self, frame):
+        right = self.right.evaluate(frame)
         return self.oper(right)
 
 
@@ -76,9 +76,9 @@ class Binary(Expr):
         elif self.oper in (add, sub, mul, div):
             return 'INTEGER'
 
-    def evaluate(self):
-        left = self.left.evaluate()
-        right = self.right.evaluate()
+    def evaluate(self, frame):
+        left = self.left.evaluate(frame)
+        right = self.right.evaluate(frame)
         return self.oper(left, right)
 
 
@@ -96,8 +96,8 @@ class Get(Expr):
         slot = self.frame[name]
         return slot['type']
 
-    def evaluate(self):
-        name = self.name.evaluate()
+    def evaluate(self, frame):
+        name = self.name.evaluate(frame)
         slot = self.frame[name]
         return slot['value']
 
@@ -113,5 +113,5 @@ class Call(Expr):
         self.callable.resolve(frame)
         return self.callable.resolve()
 
-    def evaluate(self):
-        return self.callable.evaluate()
+    def evaluate(self, frame):
+        return self.callable.evaluate(frame)

--- a/lang.py
+++ b/lang.py
@@ -12,7 +12,7 @@ class Expr:
 
     def __repr__(self):
         attrstr = ", ".join([
-            getattr(self, attr) for attr in self.__slots__
+            repr(getattr(self, attr)) for attr in self.__slots__
         ])
         return f'{type(self).__class__}({attrstr})'
 

--- a/lang.py
+++ b/lang.py
@@ -103,6 +103,22 @@ class Get(Expr):
 
 
 
+def executeStmts(frame, stmts):
+    for stmt in stmts:
+        returnval = execute(frame, stmt)
+        if returnval:
+                return returnval
+
+def assignArgsParams(frame, args, callable):
+    for arg, param in zip(args, callable['params']):
+        name = param['name'].evaluate(callable['frame'])
+        callable['frame'][name]['value'] = arg.evaluate(frame)
+
+def execCall(frame, stmt):
+    proc = stmt['name'].evaluate(frame)
+    assignArgsParams(frame, stmt['args'], proc)
+    return executeStmts(frame, proc['stmts'])
+
 class Call(Expr):
     __slots__ = ('callable', 'args')
     def __init__(self, callable, args):
@@ -114,4 +130,5 @@ class Call(Expr):
         return self.callable.resolve()
 
     def evaluate(self, frame):
-        return self.callable.evaluate(frame)
+        callable = self.callable.evaluate(frame)
+        return execCall(frame, callable)

--- a/lang.py
+++ b/lang.py
@@ -6,13 +6,10 @@ class Expr:
         raise NotImplementedError
 
     def __repr__(self):
-        return (
-            f'{type(self).__class__}('
-            f'{", ".join((
-                getattr(self, attr) for attr in self.__slots__
-            ))}'
-            ')'
-        )
+        attrstr = ", ".join([
+            getattr(self, attr) for attr in self.__slots__
+        ])
+        return f'{type(self).__class__}({attrstr})'
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -14,7 +14,7 @@ class Expr:
         attrstr = ", ".join([
             repr(getattr(self, attr)) for attr in self.__slots__
         ])
-        return f'{type(self).__class__.__name__}({attrstr})'
+        return f'{type(self).__name__}({attrstr})'
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -62,10 +62,10 @@ class Binary(Expr):
         self.right = right
 
     def resolve(self):
-    if self.oper in (lt, lte, gt, gte, ne, eq):
-        return 'BOOLEAN'
-    elif self.oper in (add, sub, mul, div):
-        return 'INTEGER'
+        if self.oper in (lt, lte, gt, gte, ne, eq):
+            return 'BOOLEAN'
+        elif self.oper in (add, sub, mul, div):
+            return 'INTEGER'
 
     def evaluate(self):
         return self.oper(self.left.value, self.right.value)

--- a/lang.py
+++ b/lang.py
@@ -107,7 +107,7 @@ class Call(Expr):
         self.args = args
 
     def resolve(self, frame=None):
-        self.callable.resolve(fram)
+        self.callable.resolve(frame)
         slot = self.callable.evaluate()
         return slot['type']
 

--- a/lang.py
+++ b/lang.py
@@ -66,7 +66,9 @@ class Binary(Expr):
         self.oper = oper
         self.right = right
 
-    def resolve(self, frame=None):
+    def resolve(self, frame):
+        self.left.resolve(frame)
+        self.right.resolve(frame)
         if self.oper in (lt, lte, gt, gte, ne, eq):
             return 'BOOLEAN'
         elif self.oper in (add, sub, mul, div):

--- a/lang.py
+++ b/lang.py
@@ -30,6 +30,19 @@ class Literal(Expr):
 
 
 
+class Name(Expr):
+    __slots__ = ('name',)
+    def __init__(self, name):
+        self.name = name
+
+    def resolve(self):
+        return 'NAME'
+
+    def evaluate(self):
+        return self.name['word']
+
+
+
 class Unary(Expr):
     __slots__ = ('oper', 'right')
     def __init__(self, oper, right):

--- a/lang.py
+++ b/lang.py
@@ -22,6 +22,12 @@ class Literal(Expr):
         self.type = type
         self.value = value
 
+    def resolve(self):
+        return self.type
+
+    def evaluate(self):
+        return self.value
+
 
 
 class Unary(Expr):

--- a/lang.py
+++ b/lang.py
@@ -56,7 +56,8 @@ class Unary(Expr):
         return self.right.resolve(frame)
 
     def evaluate(self):
-        return self.oper(self.right.value)
+        right = self.right.evaluate()
+        return self.oper(right)
 
 
 
@@ -76,7 +77,9 @@ class Binary(Expr):
             return 'INTEGER'
 
     def evaluate(self):
-        return self.oper(self.left.value, self.right.value)
+        left = self.left.evaluate()
+        right = self.right.evaluate()
+        return self.oper(left, right)
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -1,6 +1,7 @@
 from builtin import lt, lte, gt, gte, ne, eq
 from builtin import add, sub, mul, div
 from builtin import NULL
+from interpreter import execute
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -39,7 +39,7 @@ class Name(Expr):
         self.name = name
 
     def resolve(self, frame=None):
-        return 'NAME'
+        return self.name['word']
 
     def evaluate(self):
         return self.name['word']

--- a/lang.py
+++ b/lang.py
@@ -12,6 +12,9 @@ class Unary(Expr):
         self.oper = oper
         self.right = right
 
+    def __repr__(self):
+        return f'{type(self).__class__}(oper={self.oper}, right={self.right})'
+
 
 
 class Binary(Expr):
@@ -20,6 +23,9 @@ class Binary(Expr):
         self.oper = oper
         self.right = right
 
+    def __repr__(self):
+        return f'{type(self).__class__}(left={self.left}, oper={self.oper}, right={self.right})'
+
 
 
 class Get(Expr):
@@ -27,9 +33,15 @@ class Get(Expr):
         self.frame = frame
         self.name = name
 
+    def __repr__(self):
+        return f'{type(self).__class__}(name={self.name})'
+
 
 
 class Call(Expr):
     def __init__(self, callable, args):
         self.callable = callable
         self.args = args
+
+    def __repr__(self):
+        return f'{type(self).__class__}(callable={self.callable}, args={self.args})'

--- a/lang.py
+++ b/lang.py
@@ -98,3 +98,12 @@ class Call(Expr):
     def __init__(self, callable, args):
         self.callable = callable
         self.args = args
+
+    def resolve(self):
+        slot = self.callable.evaluate()
+        return slot['type']
+
+    def evaluate(self):
+        slot = self.callable.evaluate()
+        callable = slot['value']
+        # execute call and return

--- a/lang.py
+++ b/lang.py
@@ -51,6 +51,15 @@ class Binary(Expr):
         self.oper = oper
         self.right = right
 
+    def resolve(self):
+    if self.oper in (lt, lte, gt, gte, ne, eq):
+        return 'BOOLEAN'
+    elif self.oper in (add, sub, mul, div):
+        return 'INTEGER'
+
+    def evaluate(self):
+        return self.oper(self.left.value, self.right.)
+
 
 
 class Get(Expr):

--- a/lang.py
+++ b/lang.py
@@ -115,4 +115,3 @@ class Call(Expr):
 
     def evaluate(self):
         return self.callable.evaluate()
-        # execute call and return

--- a/lang.py
+++ b/lang.py
@@ -39,10 +39,10 @@ class Name(Expr):
         self.name = name
 
     def resolve(self, frame=None):
-        return self.name['word']
+        return self.name
 
     def evaluate(self):
-        return self.name['word']
+        return self.name
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -14,7 +14,7 @@ class Expr:
         attrstr = ", ".join([
             repr(getattr(self, attr)) for attr in self.__slots__
         ])
-        return f'{type(self).__class__}({attrstr})'
+        return f'{type(self).__class__.__name__}({attrstr})'
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -1,5 +1,6 @@
 from builtin import lt, lte, gt, gte, ne, eq
 from builtin import add, sub, mul, div
+from builtin import NULL
 
 
 
@@ -86,6 +87,8 @@ class Get(Expr):
         self.name = name
 
     def resolve(self, frame=None):
+        if frame and self.frame is NULL:
+            self.frame = frame
         name = self.name.evaluate()
         slot = self.frame[name]
         return slot['type']
@@ -104,6 +107,7 @@ class Call(Expr):
         self.args = args
 
     def resolve(self, frame=None):
+        self.callable.resolve(fram)
         slot = self.callable.evaluate()
         return slot['type']
 

--- a/lang.py
+++ b/lang.py
@@ -5,6 +5,15 @@ class Expr:
     def evaluate(self):
         raise NotImplementedError
 
+    def __repr__(self):
+        return (
+            f'{type(self).__class__}('
+            f'{", ".join((
+                getattr(self, attr) for attr in self.__slots__
+            ))}'
+            ')'
+        )
+
 
 
 class Unary(Expr):
@@ -12,9 +21,6 @@ class Unary(Expr):
     def __init__(self, oper, right):
         self.oper = oper
         self.right = right
-
-    def __repr__(self):
-        return f'{type(self).__class__}(oper={self.oper}, right={self.right})'
 
 
 
@@ -25,9 +31,6 @@ class Binary(Expr):
         self.oper = oper
         self.right = right
 
-    def __repr__(self):
-        return f'{type(self).__class__}(left={self.left}, oper={self.oper}, right={self.right})'
-
 
 
 class Get(Expr):
@@ -36,9 +39,6 @@ class Get(Expr):
         self.frame = frame
         self.name = name
 
-    def __repr__(self):
-        return f'{type(self).__class__}(name={self.name})'
-
 
 
 class Call(Expr):
@@ -46,6 +46,3 @@ class Call(Expr):
     def __init__(self, callable, args):
         self.callable = callable
         self.args = args
-
-    def __repr__(self):
-        return f'{type(self).__class__}(callable={self.callable}, args={self.args})'

--- a/lang.py
+++ b/lang.py
@@ -8,6 +8,7 @@ class Expr:
 
 
 class Unary(Expr):
+    __slots__ = ('oper', 'right')
     def __init__(self, oper, right):
         self.oper = oper
         self.right = right
@@ -18,6 +19,7 @@ class Unary(Expr):
 
 
 class Binary(Expr):
+    __slots__ = ('left', 'oper', 'right')
     def __init__(self, left, oper, right):
         self.left = left
         self.oper = oper
@@ -29,6 +31,7 @@ class Binary(Expr):
 
 
 class Get(Expr):
+    __slots__ = ('frame', 'name')
     def __init__(self, frame, name):
         self.frame = frame
         self.name = name
@@ -39,6 +42,7 @@ class Get(Expr):
 
 
 class Call(Expr):
+    __slots__ = ('callable', 'args')
     def __init__(self, callable, args):
         self.callable = callable
         self.args = args

--- a/lang.py
+++ b/lang.py
@@ -114,5 +114,5 @@ class Call(Expr):
         return self.callable.resolve()
 
     def evaluate(self):
-        callable = self.callable.evaluate()
+        return self.callable.evaluate()
         # execute call and return

--- a/lang.py
+++ b/lang.py
@@ -36,6 +36,12 @@ class Unary(Expr):
         self.oper = oper
         self.right = right
 
+    def resolve(self):
+        return self.right.resolve()
+
+    def evaluate(self):
+        return self.oper(self.right.value)
+
 
 
 class Binary(Expr):

--- a/lang.py
+++ b/lang.py
@@ -108,10 +108,8 @@ class Call(Expr):
 
     def resolve(self, frame=None):
         self.callable.resolve(frame)
-        slot = self.callable.evaluate()
-        return slot['type']
+        return self.callable.resolve()
 
     def evaluate(self):
-        slot = self.callable.evaluate()
-        callable = slot['value']
+        callable = self.callable.evaluate()
         # execute call and return

--- a/lang.py
+++ b/lang.py
@@ -103,22 +103,6 @@ class Get(Expr):
 
 
 
-def executeStmts(frame, stmts):
-    for stmt in stmts:
-        returnval = execute(frame, stmt)
-        if returnval:
-                return returnval
-
-def assignArgsParams(frame, args, callable):
-    for arg, param in zip(args, callable['params']):
-        name = param['name'].evaluate(callable['frame'])
-        callable['frame'][name]['value'] = arg.evaluate(frame)
-
-def execCall(frame, stmt):
-    proc = stmt['name'].evaluate(frame)
-    assignArgsParams(frame, stmt['args'], proc)
-    return executeStmts(frame, proc['stmts'])
-
 class Call(Expr):
     __slots__ = ('callable', 'args')
     def __init__(self, callable, args):
@@ -131,4 +115,11 @@ class Call(Expr):
 
     def evaluate(self, frame):
         callable = self.callable.evaluate(frame)
-        return execCall(frame, callable)
+        proc = callable['name'].evaluate(frame)
+        for arg, param in zip(callable['args'], proc['params']):
+            name = param['name'].evaluate(proc['frame'])
+            proc['frame'][name]['value'] = arg.evaluate(frame)
+        for stmt in proc['stmts']:
+            returnval = execute(frame, stmt)
+            if returnval:
+                    return returnval

--- a/lang.py
+++ b/lang.py
@@ -1,2 +1,35 @@
 class Expr:
-    pass
+    def resolve(self):
+        raise NotImplementedError
+
+    def evaluate(self):
+        raise NotImplementedError
+
+
+
+class Unary(Expr):
+    def __init__(self, oper, right):
+        self.oper = oper
+        self.right = right
+
+
+
+class Binary(Expr):
+    def __init__(self, left, oper, right):
+        self.left = left
+        self.oper = oper
+        self.right = right
+
+
+
+class Get(Expr):
+    def __init__(self, frame, name):
+        self.frame = frame
+        self.name = name
+
+
+
+class Call(Expr):
+    def __init__(self, callable, args):
+        self.callable = callable
+        self.args = args

--- a/lang.py
+++ b/lang.py
@@ -16,6 +16,14 @@ class Expr:
 
 
 
+class Literal(Expr):
+    __slots__ = ('type', 'value')
+    def __init__(self, type, value):
+        self.type = type
+        self.value = value
+
+
+
 class Unary(Expr):
     __slots__ = ('oper', 'right')
     def __init__(self, oper, right):

--- a/lang.py
+++ b/lang.py
@@ -1,3 +1,8 @@
+from builtin import lt, lte, gt, gte, ne, eq
+from builtin import add, sub, mul, div
+
+
+
 class Expr:
     def resolve(self):
         raise NotImplementedError

--- a/lang.py
+++ b/lang.py
@@ -24,7 +24,7 @@ class Literal(Expr):
         self.type = type
         self.value = value
 
-    def resolve(self):
+    def resolve(self, frame=None):
         return self.type
 
     def evaluate(self):
@@ -37,7 +37,7 @@ class Name(Expr):
     def __init__(self, name):
         self.name = name
 
-    def resolve(self):
+    def resolve(self, frame=None):
         return 'NAME'
 
     def evaluate(self):
@@ -51,7 +51,7 @@ class Unary(Expr):
         self.oper = oper
         self.right = right
 
-    def resolve(self):
+    def resolve(self, frame=None):
         return self.right.resolve()
 
     def evaluate(self):
@@ -66,7 +66,7 @@ class Binary(Expr):
         self.oper = oper
         self.right = right
 
-    def resolve(self):
+    def resolve(self, frame=None):
         if self.oper in (lt, lte, gt, gte, ne, eq):
             return 'BOOLEAN'
         elif self.oper in (add, sub, mul, div):
@@ -83,7 +83,7 @@ class Get(Expr):
         self.frame = frame
         self.name = name
 
-    def resolve(self):
+    def resolve(self, frame=None):
         name = self.name.evaluate()
         slot = self.frame[name]
         return slot['type']
@@ -101,7 +101,7 @@ class Call(Expr):
         self.callable = callable
         self.args = args
 
-    def resolve(self):
+    def resolve(self, frame=None):
         slot = self.callable.evaluate()
         return slot['type']
 

--- a/lang.py
+++ b/lang.py
@@ -58,7 +58,7 @@ class Binary(Expr):
         return 'INTEGER'
 
     def evaluate(self):
-        return self.oper(self.left.value, self.right.)
+        return self.oper(self.left.value, self.right.value)
 
 
 
@@ -67,6 +67,16 @@ class Get(Expr):
     def __init__(self, frame, name):
         self.frame = frame
         self.name = name
+
+    def resolve(self):
+        name = self.name.evaluate()
+        slot = self.frame[name]
+        return slot['type']
+
+    def evaluate(self):
+        name = self.name.evaluate()
+        slot = self.frame[name]
+        return slot['value']
 
 
 

--- a/main.py
+++ b/main.py
@@ -22,8 +22,9 @@ def main():
         statements = parser.parse(tokens)
         statements, frame = resolver.inspect(statements)
     except (ParseError, LogicError) as err:
-        lineinfo = f"[Line {err.line}]" if err.line else ""
-        print(lineinfo, lines[err.line - 1])
+        if err.line:
+            lineinfo = f"[Line {err.line}]"
+            print(lineinfo, lines[err.line - 1])
         if err.col:
             leftmargin = len(lineinfo) + 1 + err.col
             print((' ' * leftmargin) + '^')

--- a/main.py
+++ b/main.py
@@ -24,8 +24,9 @@ def main():
     except (ParseError, LogicError) as err:
         lineinfo = f"[Line {err.line}]" if err.line else ""
         print(lineinfo, lines[err.line - 1])
-        leftmargin = len(lineinfo) + 1 + err.col
-        print((' ' * leftmargin) + '^')
+        if err.col:
+            leftmargin = len(lineinfo) + 1 + err.col
+            print((' ' * leftmargin) + '^')
         print(err.report())
         sys.exit(65)
     try:

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def main():
         statements = parser.parse(tokens)
         statements, frame = resolver.inspect(statements)
     except (ParseError, LogicError) as err:
-        lineinfo = f"[Line {err.line}]"
+        lineinfo = f"[Line {err.line}]" if err.line else ""
         print(lineinfo, lines[err.line - 1])
         leftmargin = len(lineinfo) + 1 + err.col
         print((' ' * leftmargin) + '^')

--- a/parser.py
+++ b/parser.py
@@ -43,24 +43,6 @@ def makeExpr(
         return Call(callable, args)
     raise ValueError("Could not find valid keyword argument combination")
 
-def makeLiteralExpr(type, value):
-    return Literal(type, value)
-
-def makeNameExpr(name):
-    return Name(name)
-
-def makeUnaryExpr(oper, right):
-    return Unary(oper, right)
-
-def makeBinaryExpr(left, oper, right):
-    return Binary(left, oper, right)
-
-def makeGetExpr(frame, name):
-    return Get(frame, name)
-
-def makeCallExpr(callable, args):
-    return Call(callable, args)
-
 def expectElseError(tokens, word, addmsg=None):
     if check(tokens)['word'] == word:
         consume(tokens)
@@ -87,7 +69,7 @@ def value(tokens):
     token = check(tokens)
     # A single value
     if token['type'] in ['integer', 'string']:
-        expr = makeLiteralExpr(
+        expr = makeExpr(
             type=token['type'],
             value=token['value'],
         )
@@ -101,7 +83,7 @@ def value(tokens):
         frame = None
         name = identifier(tokens)
         args = []
-        expr = makeGetExpr(
+        expr = makeExpr(
             frame=frame,
             name=name,
         )
@@ -113,7 +95,7 @@ def value(tokens):
                 arg = expression(tokens)
                 args += [arg]
             expectElseError(tokens, ')', "after '('")
-            expr = makeCallExpr(
+            expr = makeExpr(
                 callable=expr,
                 args=args,
             )
@@ -127,7 +109,7 @@ def muldiv(tokens):
     while not atEnd(tokens) and check(tokens)['word'] in ('*', '/'):
         oper = consume(tokens)
         right = value(tokens)
-        expr = makeBinaryExpr(
+        expr = makeExpr(
             left=expr,
             oper=oper['value'],
             right=right,
@@ -139,7 +121,7 @@ def addsub(tokens):
     while not atEnd(tokens) and check(tokens)['word'] in ('+', '-'):
         oper = consume(tokens)
         right = muldiv(tokens)
-        expr = makeBinaryExpr(
+        expr = makeExpr(
             left=expr,
             oper=oper['value'],
             right=right,
@@ -152,7 +134,7 @@ def comparison(tokens):
     while not atEnd(tokens) and check(tokens)['word'] in ('<', '<=', '>', '>='):
         oper = consume(tokens)
         right = addsub(tokens)
-        expr = makeBinaryExpr(
+        expr = makeExpr(
             left=expr,
             oper=oper['value'],
             right=right,
@@ -165,7 +147,7 @@ def equality(tokens):
     while not atEnd(tokens) and check(tokens)['word'] in ('<>', '='):
         oper = consume(tokens)
         right = comparison(tokens)
-        expr = makeBinaryExpr(
+        expr = makeExpr(
             left=expr,
             oper=oper['value'],
             right=right,
@@ -319,7 +301,7 @@ def forStmt(tokens):
     start = value(tokens)
     expectElseError(tokens, 'TO', "after start value")
     end = value(tokens)
-    step = makeLiteralExpr(type='INTEGER', value=1)
+    step = makeExpr(type='INTEGER', value=1)
     if match(tokens, 'STEP'):
         step = value(tokens)
     expectElseError(tokens, '\n', "at end of FOR")
@@ -336,8 +318,8 @@ def forStmt(tokens):
         makeToken(end['line'], end['col'], 'keyword', '\n', None),
     ])
     # Generate loop cond
-    cond = makeBinaryExpr(
-        left=makeGetExpr(frame=None, name=name),
+    cond = makeExpr(
+        left=makeExpr(frame=None, name=name),
         oper=lte,
         right=end,
     )

--- a/parser.py
+++ b/parser.py
@@ -1,6 +1,6 @@
 from builtin import TYPES
 from builtin import ParseError
-from builtin import get, lte, add, call
+from builtin import lte, add
 from scanner import makeToken
 from lang import Literal, Name, Unary, Binary, Get, Call
 
@@ -288,12 +288,7 @@ def forStmt(tokens):
         makeToken(end['line'], end['col'], 'keyword', '\n', None),
     ])
     # Generate loop cond
-    cond = expression([
-        name,
-        makeToken(name['line'], name['col'], 'symbol', '<=', lte),
-        end,
-        makeToken(start['line'], start['col'], 'keyword', '\n', None),
-    ])
+    cond = makeBinaryExpr(makeGetExpr(None, name), lte, end)
     # Add increment statement
     incr = assignStmt([
         name,

--- a/parser.py
+++ b/parser.py
@@ -2,6 +2,7 @@ from builtin import TYPES
 from builtin import ParseError
 from builtin import get, lte, add, call
 from scanner import makeToken
+from lang import Literal, Name, Unary, Binary, Get, Call
 
 
 

--- a/parser.py
+++ b/parser.py
@@ -20,6 +20,9 @@ def consume(tokens):
     token = tokens.pop(0)
     return token
 
+def makeExpr(**kwargs):
+    pass
+
 def makeLiteralExpr(type, value):
     return Literal(type, value)
 

--- a/parser.py
+++ b/parser.py
@@ -81,14 +81,13 @@ def value(tokens):
         expectElseError(tokens, ')', "after '('")
         return expr        
     elif token['type'] == 'name':
-        frame = NULL
         name = identifier(tokens)
-        args = []
         expr = makeExpr(
-            frame=frame,
+            frame=NULL,
             name=name,
         )
         # Function call
+        args = []
         if match(tokens, '('):
             arg = expression(tokens)
             args += [arg]

--- a/parser.py
+++ b/parser.py
@@ -66,13 +66,14 @@ def identifier(tokens):
         raise ParseError(f"Expected variable name", token)
 
 def value(tokens):
-    token = consume(tokens)
+    token = check(tokens)
     # A single value
     if token['type'] in ['integer', 'string']:
         expr = makeExpr(
             type=token['type'],
             value=token['value'],
         )
+        consume(tokens)
         return expr
     #  A grouping
     elif match(tokens, '('):

--- a/parser.py
+++ b/parser.py
@@ -59,14 +59,14 @@ def match(tokens, *words):
 # Precedence parsers
 
 def identifier(tokens):
-    token = check(tokens)
+    token = consume(tokens)
     if token['type'] == 'name':
         return Name(token['word'])
     else:
         raise ParseError(f"Expected variable name", token)
 
 def value(tokens):
-    token = check(tokens)
+    token = consume(tokens)
     # A single value
     if token['type'] in ['integer', 'string']:
         expr = makeExpr(

--- a/parser.py
+++ b/parser.py
@@ -27,19 +27,19 @@ def makeExpr(
     left=None, oper=None, right=None,
     callable=None, args=None,
 ):
-    if 'name':
-        if 'frame':
+    if name is not None:
+        if frame is not None:
             return Get(frame, name)
         else:
             return Name(name)
-    if type and value:
+    if type is not None and value is not None:
         return Literal(type, value)
-    if oper and right:
-        if left:
+    if oper is not None and right is not None:
+        if left is not None:
             return Binary(left, oper, right)
         else:
             return Unary(oper, right)
-    if callable and args:
+    if callable is not None and args is not None:
         return Call(callable, args)
     raise ValueError("Could not find valid keyword argument combination")
 

--- a/parser.py
+++ b/parser.py
@@ -27,7 +27,21 @@ def makeExpr(
     left=None, oper=None, right=None,
     callable=None, args=None,
 ):
-    pass
+    if 'name':
+        if 'frame':
+            return Get(frame, name)
+        else:
+            return Name(name)
+    if type and value:
+        return Literal(type, value)
+    if oper and right:
+        if left:
+            return Binary(left, oper, right)
+        else:
+            return Unary(oper, right)
+    if callable and args:
+        return Call(callable, args)
+    raise ValueError("Could not find valid keyword argument combination")
 
 def makeLiteralExpr(type, value):
     return Literal(type, value)

--- a/parser.py
+++ b/parser.py
@@ -64,7 +64,10 @@ def value(tokens):
     token = check(tokens)
     # A single value
     if token['type'] in ['integer', 'string']:
-        expr = makeLiteralExpr(token['type'], token['value'])
+        expr = makeLiteralExpr(
+            type=token['type'],
+            value=token['value'],
+        )
         return expr
     #  A grouping
     elif match(tokens, '('):
@@ -75,7 +78,10 @@ def value(tokens):
         frame = None
         name = identifier(tokens)
         args = []
-        expr = makeGetExpr(frame, name)
+        expr = makeGetExpr(
+            frame=frame,
+            name=name,
+        )
         # Function call
         if match(tokens, '('):
             arg = expression(tokens)
@@ -84,7 +90,10 @@ def value(tokens):
                 arg = expression(tokens)
                 args += [arg]
             expectElseError(tokens, ')', "after '('")
-            expr = makeCallExpr(expr, args)
+            expr = makeCallExpr(
+                callable=expr,
+                args=args,
+            )
         return expr
     else:
         raise ParseError("Unexpected token", token)
@@ -95,7 +104,11 @@ def muldiv(tokens):
     while not atEnd(tokens) and check(tokens)['word'] in ('*', '/'):
         oper = consume(tokens)
         right = value(tokens)
-        expr = makeBinaryExpr(expr, oper['value'], right)
+        expr = makeBinaryExpr(
+            left=expr,
+            oper=oper['value'],
+            right=right,
+        )
     return expr
 
 def addsub(tokens):
@@ -103,7 +116,11 @@ def addsub(tokens):
     while not atEnd(tokens) and check(tokens)['word'] in ('+', '-'):
         oper = consume(tokens)
         right = muldiv(tokens)
-        expr = makeBinaryExpr(expr, oper['value'], right)
+        expr = makeBinaryExpr(
+            left=expr,
+            oper=oper['value'],
+            right=right,
+        )
     return expr
 
 def comparison(tokens):
@@ -112,7 +129,11 @@ def comparison(tokens):
     while not atEnd(tokens) and check(tokens)['word'] in ('<', '<=', '>', '>='):
         oper = consume(tokens)
         right = addsub(tokens)
-        expr = makeBinaryExpr(expr, oper['value'], right)
+        expr = makeBinaryExpr(
+            left=expr,
+            oper=oper['value'],
+            right=right,
+        )
     return expr
 
 def equality(tokens):
@@ -121,7 +142,11 @@ def equality(tokens):
     while not atEnd(tokens) and check(tokens)['word'] in ('<>', '='):
         oper = consume(tokens)
         right = comparison(tokens)
-        expr = makeBinaryExpr(expr, oper['value'], right)
+        expr = makeBinaryExpr(
+            left=expr,
+            oper=oper['value'],
+            right=right,
+        )
     return expr
 
 def expression(tokens):
@@ -271,7 +296,7 @@ def forStmt(tokens):
     start = value(tokens)
     expectElseError(tokens, 'TO', "after start value")
     end = value(tokens)
-    step = makeLiteralExpr('INTEGER', 1)
+    step = makeLiteralExpr(type='INTEGER', value=1)
     if match(tokens, 'STEP'):
         step = value(tokens)
     expectElseError(tokens, '\n', "at end of FOR")
@@ -288,7 +313,11 @@ def forStmt(tokens):
         makeToken(end['line'], end['col'], 'keyword', '\n', None),
     ])
     # Generate loop cond
-    cond = makeBinaryExpr(makeGetExpr(None, name), lte, end)
+    cond = makeBinaryExpr(
+        left=makeGetExpr(frame=None, name=name),
+        oper=lte,
+        right=end,
+    )
     # Add increment statement
     incr = assignStmt([
         name,

--- a/parser.py
+++ b/parser.py
@@ -53,8 +53,6 @@ def match(tokens, *words):
 
 # Precedence parsers
 
-# Expr: {'left': ..., 'oper': ..., 'right': ...}
-
 def identifier(tokens):
     token = check(tokens)
     if token['type'] == 'name':
@@ -76,19 +74,16 @@ def value(tokens):
     elif token['type'] == 'name':
         frame = None
         name = identifier(tokens)
-        oper = makeToken(name['line'], name['col'], 'symbol', '', get)
         args = []
         expr = makeGetExpr(frame, name)
         # Function call
         if match(tokens, '('):
-            thisline = tokens[0]['line']
             arg = expression(tokens)
             args += [arg]
             while match(tokens, ','):
                 arg = expression(tokens)
                 args += [arg]
             expectElseError(tokens, ')', "after '('")
-            oper = makeToken(name['line'], name['col'], 'symbol', '', call)
             expr = makeCallExpr(expr, args)
         return expr
     else:

--- a/parser.py
+++ b/parser.py
@@ -20,7 +20,13 @@ def consume(tokens):
     token = tokens.pop(0)
     return token
 
-def makeExpr(**kwargs):
+def makeExpr(
+    *,
+    type=None, value=None,
+    frame=None, name=None,
+    left=None, oper=None, right=None,
+    callable=None, args=None,
+):
     pass
 
 def makeLiteralExpr(type, value):

--- a/parser.py
+++ b/parser.py
@@ -68,7 +68,7 @@ def identifier(tokens):
 def value(tokens):
     token = check(tokens)
     # A single value
-    if token['type'] in ['integer', 'string']:
+    if token['type'] in ['INTEGER', 'STRING']:
         expr = makeExpr(
             type=token['type'],
             value=token['value'],

--- a/parser.py
+++ b/parser.py
@@ -1,4 +1,4 @@
-from builtin import TYPES
+from builtin import TYPES, NULL
 from builtin import ParseError
 from builtin import lte, add
 from scanner import makeToken
@@ -81,7 +81,7 @@ def value(tokens):
         expectElseError(tokens, ')', "after '('")
         return expr        
     elif token['type'] == 'name':
-        frame = None
+        frame = NULL
         name = identifier(tokens)
         args = []
         expr = makeExpr(

--- a/resolver.py
+++ b/resolver.py
@@ -144,10 +144,7 @@ def verifyProcedure(frame, stmt):
     }
 
 def verifyCall(frame, stmt):
-    # Insert frame
-    stmt['name']['left'] = frame
-    # resolve() would return the expr type, but we need the name
-    name = resolve(frame, stmt['name']['right'])
+    name = stmt['name'].resolve(frame)
     proc = frame[name]
     expectTypeElseError(frame, proc, 'procedure')
     args, params = stmt['args'], proc['value']['params']
@@ -167,7 +164,7 @@ def verifyCall(frame, stmt):
                     'BYREF arg must be a name, not expression',
                     stmt['passby'],
                 )
-        paramtype = resolve(local, param['type'])
+        paramtype = param['type']['word']
         expectTypeElseError(frame, arg, paramtype)
 
 def verifyFunction(frame, stmt):

--- a/resolver.py
+++ b/resolver.py
@@ -76,11 +76,11 @@ def verifyOutput(frame, stmt):
     resolveExprs(frame, stmt['exprs'])
 
 def verifyInput(frame, stmt):
-    name = resolve(frame, stmt['name'])
+    name = stmt['name'].resolve()
     if name not in frame:
         raise LogicError(
             f'Name not declared',
-            stmt['name'],
+            stmt['name'].name,
         )
 
 def verifyDeclare(frame, stmt):

--- a/resolver.py
+++ b/resolver.py
@@ -10,12 +10,14 @@ from builtin import LogicError
 def expectTypeElseError(frame, expr, expected):
     exprtype = expr.resolve(frame)
     if expected != exprtype:
-        if 'line' in expr:
-            token = expr
-        elif 'line' in expr['left']:
-            token = expr['left']
-        elif 'line' in expr['right']:
-            token = expr['right']
+        token = None
+        if type(expr) is dict:
+            if 'line' in expr:
+                token = expr
+            elif 'line' in expr['left']:
+                token = expr['left']
+            elif 'line' in expr['right']:
+                token = expr['right']
         raise LogicError(
             f"Expected {repr(expected)}, got {repr(exprtype)}",
             token,

--- a/resolver.py
+++ b/resolver.py
@@ -8,7 +8,7 @@ from builtin import LogicError
 # Helper functions
 
 def expectTypeElseError(frame, expr, expected):
-    exprtype = resolve(frame, expr)
+    exprtype = expr.resolve(frame)
     if expected != exprtype:
         if 'line' in expr:
             token = expr
@@ -23,7 +23,7 @@ def expectTypeElseError(frame, expr, expected):
 
 def resolveExprs(frame, exprs):
     for expr in exprs:
-        resolve(frame, expr)
+        expr.resolve(frame)
 
 def verifyStmts(frame, stmts):
     for stmt in stmts:

--- a/resolver.py
+++ b/resolver.py
@@ -84,8 +84,8 @@ def verifyInput(frame, stmt):
         )
 
 def verifyDeclare(frame, stmt):
-    name = resolve(frame, stmt['name'])
-    type_ = resolve(frame, stmt['type'])
+    name = stmt['name'].resolve()
+    type_ = stmt['type']['word']
     frame[name] = {'type': type_, 'value': None}
 
 def verifyAssign(frame, stmt):

--- a/resolver.py
+++ b/resolver.py
@@ -173,9 +173,9 @@ def verifyFunction(frame, stmt):
     for var in stmt['params']:
         # Declare vars in local
         verifyDeclare(local, var)
-    # Resolve procedure statements using local
     name = stmt['name'].resolve(frame)
     returns = stmt['returns'].resolve(frame)
+    # Resolve procedure statements using local
     for procstmt in stmt['stmts']:
         returntype = verify(local, procstmt)
         if returntype and (returntype != returns):

--- a/resolver.py
+++ b/resolver.py
@@ -121,7 +121,7 @@ def verifyProcedure(frame, stmt):
         if passby == 'BYVALUE':
             verifyDeclare(local, var)
         elif passby == 'BYREF':
-            name = resolve(frame, var['name'])
+            name = var['name'].resolve(frame)
             globvar = frame[name]
             expectTypeElseError(frame, var['type'], globvar['type'])
             # Reference global vars in local
@@ -132,7 +132,7 @@ def verifyProcedure(frame, stmt):
     # Resolve procedure statements using local
     verifyStmts(local, stmt['stmts'])
     # Declare procedure in frame
-    name = resolve(frame, stmt['name'])
+    name = stmt['name'].resolve(frame)
     frame[name] = {
         'type': 'procedure',
         'value': {
@@ -177,8 +177,8 @@ def verifyFunction(frame, stmt):
         # Declare vars in local
         verifyDeclare(local, var)
     # Resolve procedure statements using local
-    name = resolve(frame, stmt['name'])
-    returns = resolve(frame, stmt['returns'])
+    name = stmt['name'].resolve(frame)
+    returns = stmt['returns'].resolve(frame)
     for procstmt in stmt['stmts']:
         returntype = verify(local, procstmt)
         if returntype and (returntype != returns):

--- a/resolver.py
+++ b/resolver.py
@@ -201,8 +201,7 @@ def verifyReturn(local, stmt):
     return stmt['expr'].resolve(local)
 
 def verifyFile(frame, stmt):
-    # resolve() returns type instead of string value
-    name = stmt['name']['value']
+    name = stmt['name'].resolve(frame)
     if stmt['action'] == 'open':
         if name in frame:
             raise LogicError("File already opened", stmt['name'])
@@ -215,7 +214,7 @@ def verifyFile(frame, stmt):
         if file['type'] != 'READ':
             raise LogicError("File mode is {file['type']}", stmt['name'])
     elif stmt['action'] == 'write':
-        resolve(frame, stmt['data'])
+        stmt['data'].resolve(frame)
         if name not in frame:
             raise LogicError("File not open", stmt['name'])
         file = frame[name]

--- a/resolver.py
+++ b/resolver.py
@@ -198,7 +198,7 @@ def verifyReturn(local, stmt):
     # This will typically be verify()ed within
     # verifyFunction(), so frame is expected to
     # be local
-    return resolve(local, stmt['expr'])
+    return stmt['expr'].resolve(local)
 
 def verifyFile(frame, stmt):
     # resolve() returns type instead of string value

--- a/resolver.py
+++ b/resolver.py
@@ -89,7 +89,7 @@ def verifyDeclare(frame, stmt):
     frame[name] = {'type': type_, 'value': None}
 
 def verifyAssign(frame, stmt):
-    name = resolve(frame, stmt['name'])
+    name = stmt['name'].resolve(frame)
     expectTypeElseError(frame, stmt['expr'], frame[name]['type'])
 
 def verifyCase(frame, stmt):

--- a/resolver.py
+++ b/resolver.py
@@ -76,7 +76,7 @@ def verifyOutput(frame, stmt):
     resolveExprs(frame, stmt['exprs'])
 
 def verifyInput(frame, stmt):
-    name = stmt['name'].resolve()
+    name = stmt['name'].resolve(frame)
     if name not in frame:
         raise LogicError(
             f'Name not declared',
@@ -84,7 +84,7 @@ def verifyInput(frame, stmt):
         )
 
 def verifyDeclare(frame, stmt):
-    name = stmt['name'].resolve()
+    name = stmt['name'].resolve(frame)
     type_ = stmt['type']['word']
     frame[name] = {'type': type_, 'value': None}
 

--- a/resolver.py
+++ b/resolver.py
@@ -93,13 +93,13 @@ def verifyAssign(frame, stmt):
     expectTypeElseError(frame, stmt['expr'], frame[name]['type'])
 
 def verifyCase(frame, stmt):
-    resolve(frame, stmt['cond'])
+    stmt['cond'].resolve(frame)
     verifyStmts(frame, stmt['stmts'].values())
     if stmt['fallback']:
         verify(frame, stmt['fallback'])
 
 def verifyIf(frame, stmt):
-    resolve(frame, stmt['cond'])
+    stmt['cond'].resolve(frame)
     expectTypeElseError(frame, stmt['cond'], 'BOOLEAN')
     verifyStmts(frame, stmt['stmts'][True])
     if stmt['fallback']:
@@ -108,7 +108,7 @@ def verifyIf(frame, stmt):
 def verifyWhile(frame, stmt):
     if stmt['init']:
         verify(frame, stmt['init'])
-    resolve(frame, stmt['cond']['left'])
+    stmt['cond'].resolve(frame)
     expectTypeElseError(frame, stmt['cond'], 'BOOLEAN')
     verifyStmts(frame, stmt['stmts'])
 

--- a/scanner.py
+++ b/scanner.py
@@ -112,7 +112,7 @@ def scan(src):
             token = makeToken(
                 code['line'],
                 code['cursor'] - code['lineStart'] - len(text),
-                'integer',
+                'INTEGER',
                 text,
                 int(text),
             )
@@ -121,7 +121,7 @@ def scan(src):
             token = makeToken(
                 code['line'],
                 code['cursor'] - code['lineStart'] - len(text),
-                'string',
+                'STRING',
                 text,
                 text[1:-1],
             )


### PR DESCRIPTION
We are hitting the limit of what we can do for expressions using only dicts. Up to this point we've been shoehorning all kinds of expressions—`call` expressions, `get` expressions, binary expressions, and even unary expressions—into an expr` with a `'left'`, `'oper'`, and `'right'`.

Let's do it the "proper" way with object-oriented programming (OOP) so that we can easily extend our interpreter to support other kinds of expressions.