### PR TITLE
16b OOP: Statements

### DIFF
--- a/interpreter.py
+++ b/interpreter.py
@@ -55,14 +55,14 @@ def execAssign(frame, stmt):
 
 def execCase(frame, stmt):
     cond = stmt.cond.evaluate(frame)
-    if cond in stmt.stmts:
-        execute(frame, stmt.stmts[cond])
+    if cond in stmt.stmtMap:
+        execute(frame, stmt.stmtMap[cond])
     elif stmt.fallback:
         execute(frame, stmt.fallback)
 
 def execIf(frame, stmt):
     if stmt.cond.evaluate(frame):
-        executeStmts(frame, stmt.stmts[True])
+        executeStmts(frame, stmt.stmtMap[True])
     elif stmt.fallback:
         executeStmts(frame, stmt.fallback)
 
@@ -84,7 +84,7 @@ def execFunction(frame, stmt):
     pass
 
 def execCall(frame, stmt):
-    proc = stmt.name.evaluate(frame)
+    proc = stmt.callable.evaluate(frame)
     assignArgsParams(frame, stmt.args, proc)
     return executeStmts(frame, proc.stmts)
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -7,9 +7,9 @@ from builtin import RuntimeError
 
 def executeStmts(frame, stmts):
     for stmt in stmts:
-        returnval = execute(frame, stmt)
+        returnval = stmt.accept(frame, execute)
         if returnval:
-                return returnval
+            return returnval
 
 def assignArgsParams(frame, args, callable):
     for arg, param in zip(args, callable['params']):
@@ -123,31 +123,31 @@ def execFile(frame, stmt):
 
 def execute(frame, stmt):
     if stmt['rule'] == 'output':
-        execOutput(frame, stmt)
+        stmt.accept(frame, execOutput)
     if stmt['rule'] == 'input':
-        execInput(frame, stmt)
+        stmt.accept(frame, execInput)
     if stmt['rule'] == 'declare':
-        execDeclare(frame, stmt)
+        stmt.accept(frame, execDeclare)
     if stmt['rule'] == 'assign':
-        execAssign(frame, stmt)
+        stmt.accept(frame, execAssign)
     if stmt['rule'] == 'case':
-        execCase(frame, stmt)
+        stmt.accept(frame, execCase)
     if stmt['rule'] == 'if':
-        execIf(frame, stmt)
+        stmt.accept(frame, execIf)
     if stmt['rule'] == 'while':
-        execWhile(frame, stmt)
+        stmt.accept(frame, execWhile)
     if stmt['rule'] == 'repeat':
-        execRepeat(frame, stmt)
+        stmt.accept(frame, execRepeat)
     if stmt['rule'] == 'procedure':
-        execProcedure(frame, stmt)
+        stmt.accept(frame, execProcedure)
     if stmt['rule'] == 'call':
-        execCall(frame, stmt)
+        stmt.accept(frame, execCall)
     if stmt['rule'] == 'function':
-        execFunction(frame, stmt)
+        stmt.accept(frame, execFunction)
     if stmt['rule'] == 'return':
-        return execReturn(frame, stmt)
+        return stmt.accept(frame, execReturn)
     if stmt['rule'] == 'file':
-        execFile(frame, stmt)
+        stmt.accept(frame, execFile)
 
 def interpret(statements, frame=None):
     if frame is None:

--- a/interpreter.py
+++ b/interpreter.py
@@ -100,7 +100,7 @@ def execFile(frame, stmt):
         assert stmt.mode  # Internal check
         file = {
             'type': stmt.mode,
-            'value': open(name, mode[0].lower()),
+            'value': open(name, stmt.mode[0].lower()),
         }
         frame[name] = file
     elif stmt.action == 'read':

--- a/interpreter.py
+++ b/interpreter.py
@@ -37,45 +37,45 @@ def evaluate(frame, expr):
     return oper(left, right)
 
 def execOutput(frame, stmt):
-    for expr in stmt['exprs']:
+    for expr in stmt.exprs:
         print(str(expr.evaluate(frame)), end='')
     print('')  # Add \n
 
 def execInput(frame, stmt):
-    name = stmt['name'].evaluate(frame)
+    name = stmt.name.evaluate(frame)
     frame[name]['value'] = input()
 
 def execDeclare(frame, stmt):
     pass
 
 def execAssign(frame, stmt):
-    name = stmt['name'].evaluate(frame)
-    value = stmt['expr'].evaluate(frame)
+    name = stmt.name.evaluate(frame)
+    value = stmt.expr.evaluate(frame)
     frame[name]['value'] = value
 
 def execCase(frame, stmt):
-    cond = stmt['cond'].evaluate(frame)
-    if cond in stmt['stmts']:
-        execute(frame, stmt['stmts'][cond])
-    elif stmt['fallback']:
-        execute(frame, stmt['fallback'])
+    cond = stmt.cond.evaluate(frame)
+    if cond in stmt.stmts:
+        execute(frame, stmt.stmts[cond])
+    elif stmt.fallback:
+        execute(frame, stmt.fallback)
 
 def execIf(frame, stmt):
-    if stmt['cond'].evaluate(frame):
-        executeStmts(frame, stmt['stmts'][True])
-    elif stmt['fallback']:
-        executeStmts(frame, stmt['fallback'])
+    if stmt.cond.evaluate(frame):
+        executeStmts(frame, stmt.stmts[True])
+    elif stmt.fallback:
+        executeStmts(frame, stmt.fallback)
 
 def execWhile(frame, stmt):
-    if stmt['init']:
-        execute(frame, stmt['init'])
-    while stmt['cond'].evaluate(frame) is True:
-        executeStmts(frame, stmt['stmts'])
+    if stmt.init:
+        execute(frame, stmt.init)
+    while stmt.cond.evaluate(frame) is True:
+        executeStmts(frame, stmt.stmts)
 
 def execRepeat(frame, stmt):
-    executeStmts(frame, stmt['stmts'])
-    while stmt['cond'].evaluate(frame) is False:
-        executeStmts(frame, stmt['stmts'])
+    executeStmts(frame, stmt.stmts)
+    while stmt.cond.evaluate(frame) is False:
+        executeStmts(frame, stmt.stmts)
 
 def execProcedure(frame, stmt):
     pass
@@ -84,69 +84,68 @@ def execFunction(frame, stmt):
     pass
 
 def execCall(frame, stmt):
-    proc = stmt['name'].evaluate(frame)
-    assignArgsParams(frame, stmt['args'], proc)
-    return executeStmts(frame, proc['stmts'])
+    proc = stmt.name.evaluate(frame)
+    assignArgsParams(frame, stmt.args, proc)
+    return executeStmts(frame, proc.stmts)
 
 def execReturn(local, stmt):
     # This will typically be execute()ed within
     # evaluate() in a function call, so frame is expected
     # to be local
-    return stmt['expr'].evaluate(local)
+    return stmt.expr.evaluate(local)
 
 def execFile(frame, stmt):
-    name = stmt['name'].evaluate(frame)
-    if stmt['action'] == 'open':
-        mode = stmt['mode']['word']
-        assert mode  # Internal check
+    name = stmt.name.evaluate(frame)
+    if stmt.action == 'open':
+        assert stmt.mode  # Internal check
         file = {
-            'type': mode,
+            'type': stmt.mode,
             'value': open(name, mode[0].lower()),
         }
         frame[name] = file
-    elif stmt['action'] == 'read':
+    elif stmt.action == 'read':
         file = frame[name]
-        varname = stmt['data'].evaluate(frame)
+        varname = stmt.data.evaluate(frame)
         line = file['value'].readline().rstrip()
         frame[varname]['value'] = line
-    elif stmt['action'] == 'write':
+    elif stmt.action == 'write':
         file = frame[name]
-        writedata = str(stmt['data'].evaluate(frame))
+        writedata = str(stmt.data.evaluate(frame))
         # Move pointer to next line after writing
         if not writedata.endswith('\n'):
             writedata += '\n'
         file['value'].write(writedata)
-    elif stmt['action'] == 'close':
+    elif stmt.action == 'close':
         file = frame[name]
         file['value'].close()
         del frame[name]
 
 def execute(frame, stmt):
-    if stmt['rule'] == 'output':
+    if stmt.rule == 'output':
         stmt.accept(frame, execOutput)
-    if stmt['rule'] == 'input':
+    if stmt.rule == 'input':
         stmt.accept(frame, execInput)
-    if stmt['rule'] == 'declare':
+    if stmt.rule == 'declare':
         stmt.accept(frame, execDeclare)
-    if stmt['rule'] == 'assign':
+    if stmt.rule == 'assign':
         stmt.accept(frame, execAssign)
-    if stmt['rule'] == 'case':
+    if stmt.rule == 'case':
         stmt.accept(frame, execCase)
-    if stmt['rule'] == 'if':
+    if stmt.rule == 'if':
         stmt.accept(frame, execIf)
-    if stmt['rule'] == 'while':
+    if stmt.rule == 'while':
         stmt.accept(frame, execWhile)
-    if stmt['rule'] == 'repeat':
+    if stmt.rule == 'repeat':
         stmt.accept(frame, execRepeat)
-    if stmt['rule'] == 'procedure':
+    if stmt.rule == 'procedure':
         stmt.accept(frame, execProcedure)
-    if stmt['rule'] == 'call':
+    if stmt.rule == 'call':
         stmt.accept(frame, execCall)
-    if stmt['rule'] == 'function':
+    if stmt.rule == 'function':
         stmt.accept(frame, execFunction)
-    if stmt['rule'] == 'return':
+    if stmt.rule == 'return':
         return stmt.accept(frame, execReturn)
-    if stmt['rule'] == 'file':
+    if stmt.rule == 'file':
         stmt.accept(frame, execFile)
 
 def interpret(statements, frame=None):

--- a/lang.py
+++ b/lang.py
@@ -136,9 +136,6 @@ class Stmt:
     def verify(self, frame=None):
         raise NotImplementedError
 
-    def execute(self, frame=None):
-        raise NotImplementedError
-
     def __repr__(self):
         attrstr = ", ".join([
             repr(getattr(self, attr)) for attr in self.__slots__
@@ -156,9 +153,6 @@ class Output(Stmt):
     def verify(self, frame):
         pass
 
-    def execute(self, frame):
-        pass
-
 
 
 class Input(Stmt):
@@ -168,9 +162,6 @@ class Input(Stmt):
         self.name = name
 
     def verify(self, frame):
-        pass
-
-    def execute(self, frame):
         pass
 
 
@@ -185,9 +176,6 @@ class Declare(Stmt):
     def verify(self, frame):
         pass
 
-    def execute(self, frame):
-        pass
-
 
 
 class Assign(Stmt):
@@ -198,9 +186,6 @@ class Assign(Stmt):
         self.expr = expr
 
     def verify(self, frame):
-        pass
-
-    def execute(self, frame):
         pass
 
 
@@ -216,9 +201,6 @@ class Conditional(Stmt):
     def verify(self, frame):
         pass
 
-    def execute(self, frame):
-        pass
-
 
 
 class Loop(Stmt):
@@ -230,9 +212,6 @@ class Loop(Stmt):
         self.stmts = stmts
 
     def verify(self, frame):
-        pass
-
-    def execute(self, frame):
         pass
 
 
@@ -250,9 +229,6 @@ class Callable(Stmt):
     def verify(self, frame):
         pass
 
-    def execute(self, frame):
-        pass
-
 
 
 class Calling(Stmt):
@@ -267,9 +243,6 @@ class Calling(Stmt):
     def verify(self, frame):
         pass
 
-    def execute(self, frame):
-        pass
-
 
 
 class Return(Stmt):
@@ -279,9 +252,6 @@ class Return(Stmt):
         self.expr = expr
 
     def verify(self, frame):
-        pass
-
-    def execute(self, frame):
         pass
 
 
@@ -296,7 +266,4 @@ class File(Stmt):
         self.data = data
 
     def verify(self, frame):
-        pass
-
-    def execute(self, frame):
         pass

--- a/lang.py
+++ b/lang.py
@@ -209,11 +209,10 @@ class Callable(Stmt):
 class Calling(Stmt):
     # HACK: Temporary replacement for a lack of an ExprStmt
     # Should attempt to use Call Expr
-    __slots__ = ('rule', 'callable', 'args')
-    def __init__(self, rule, callable, args):
+    __slots__ = ('rule', 'callable')
+    def __init__(self, rule, callable):
         self.rule = rule
         self.callable = callable
-        self.args = args
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -124,3 +124,18 @@ class Call(Expr):
             returnval = execute(frame, stmt)
             if returnval:
                     return returnval
+
+
+
+class Stmt:
+    def verify(self, frame=None):
+        raise NotImplementedError
+
+    def execute(self, frame=None):
+        raise NotImplementedError
+
+    def __repr__(self):
+        attrstr = ", ".join([
+            repr(getattr(self, attr)) for attr in self.__slots__
+        ])
+        return f'{type(self).__name__}({attrstr})'

--- a/lang.py
+++ b/lang.py
@@ -139,3 +139,142 @@ class Stmt:
             repr(getattr(self, attr)) for attr in self.__slots__
         ])
         return f'{type(self).__name__}({attrstr})'
+
+
+
+class Output(Stmt):
+    __slots__ = ('rule', 'exprs')
+    def __init__(self, rule, exprs):
+        self.rule = rule
+        self.exprs = exprs
+
+    def verify(self, frame):
+        pass
+
+    def execute(self, frame):
+        pass
+
+
+
+class Input(Stmt):
+    __slots__ = ('rule', 'name')
+    def __init__(self, rule, name):
+        self.rule = rule
+        self.name = name
+
+    def verify(self, frame):
+        pass
+
+    def execute(self, frame):
+        pass
+
+
+
+class Declare(Stmt):
+    __slots__ = ('rule', 'name', 'type')
+    def __init__(self, rule, name, type):
+        self.rule = rule
+        self.name = name
+        self.type = type
+
+    def verify(self, frame):
+        pass
+
+    def execute(self, frame):
+        pass
+
+
+
+class Assign(Stmt):
+    __slots__ = ('rule', 'name', 'expr')
+    def __init__(self, rule, name, expr):
+        self.rule = rule
+        self.name = name
+        self.expr = expr
+
+    def verify(self, frame):
+        pass
+
+    def execute(self, frame):
+        pass
+
+
+
+class Conditional(Stmt):
+    __slots__ = ('rule', 'cond', 'stmtMap', 'fallback')
+    def __init__(self, rule, cond, stmtMap, fallback):
+        self.rule = rule
+        self.cond = cond
+        self.stmtMap = stmtMap
+        self.fallback = fallback
+
+    def verify(self, frame):
+        pass
+
+    def execute(self, frame):
+        pass
+
+
+
+class Loop(Stmt):
+    __slots__ = ('rule', 'init', 'cond', 'stmts')
+    def __init__(self, rule, init, cond, stmts):
+        self.rule = rule
+        self.init = init
+        self.cond = cond
+        self.stmts = stmts
+
+    def verify(self, frame):
+        pass
+
+    def execute(self, frame):
+        pass
+
+
+
+class Callable(Stmt):
+    __slots__ = ('rule', 'name', 'passby', 'params', 'stmts', 'returnType')
+    def __init__(self, rule, name, passby, params, stmts, returnType):
+        self.rule = rule
+        self.name = name
+        self.passby = passby
+        self.params = params
+        self.stmts = stmts
+        self.returnType = returnType
+
+    def verify(self, frame):
+        pass
+
+    def execute(self, frame):
+        pass
+
+
+
+class Return(Stmt):
+    __slots__ = ('rule', 'expr')
+    def __init__(self, rule, expr):
+        self.rule = rule
+        self.expr = expr
+
+    def verify(self, frame):
+        pass
+
+    def execute(self, frame):
+        pass
+
+
+
+class File(Stmt):
+    __slots__ = ('rule', 'action', 'name', 'mode', 'data')
+    def __init__(self, rule, action, name, mode, data):
+        self.rule = rule
+        self.action = action
+        self.name = name
+        self.mode = mode
+        self.data = data
+
+    def verify(self, frame):
+        pass
+
+    def execute(self, frame):
+        pass

--- a/lang.py
+++ b/lang.py
@@ -122,7 +122,7 @@ class Call(Expr):
         for stmt in proc['stmts']:
             returnval = execute(frame, stmt)
             if returnval:
-                    return returnval
+                return returnval
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -115,9 +115,8 @@ class Call(Expr):
         return self.callable.resolve()
 
     def evaluate(self, frame):
-        callable = self.callable.evaluate(frame)
-        proc = callable['name'].evaluate(frame)
-        for arg, param in zip(callable['args'], proc['params']):
+        proc = self.callable.evaluate(frame)
+        for arg, param in zip(self.args, proc['params']):
             name = param['name'].evaluate(proc['frame'])
             proc['frame'][name]['value'] = arg.evaluate(frame)
         for stmt in proc['stmts']:

--- a/lang.py
+++ b/lang.py
@@ -128,6 +128,11 @@ class Call(Expr):
 
 
 class Stmt:
+    def accept(self, frame, visitor):
+        # visitor must be a function that takes
+        # a frame and a Stmt
+        return visitor(frame, self)
+
     def verify(self, frame=None):
         raise NotImplementedError
 

--- a/lang.py
+++ b/lang.py
@@ -250,6 +250,23 @@ class Callable(Stmt):
 
 
 
+class Calling(Stmt):
+    # HACK: Temporary replacement for a lack of an ExprStmt
+    # Should attempt to use Call Expr
+    __slots__ = ('rule', 'callable', 'args')
+    def __init__(self, rule, callable, args):
+        self.rule = rule
+        self.callable = callable
+        self.args = args
+
+    def verify(self, frame):
+        pass
+
+    def execute(self, frame):
+        pass
+
+
+
 class Return(Stmt):
     __slots__ = ('rule', 'expr')
     def __init__(self, rule, expr):

--- a/lang.py
+++ b/lang.py
@@ -133,9 +133,6 @@ class Stmt:
         # a frame and a Stmt
         return visitor(frame, self)
 
-    def verify(self, frame=None):
-        raise NotImplementedError
-
     def __repr__(self):
         attrstr = ", ".join([
             repr(getattr(self, attr)) for attr in self.__slots__
@@ -150,9 +147,6 @@ class Output(Stmt):
         self.rule = rule
         self.exprs = exprs
 
-    def verify(self, frame):
-        pass
-
 
 
 class Input(Stmt):
@@ -160,9 +154,6 @@ class Input(Stmt):
     def __init__(self, rule, name):
         self.rule = rule
         self.name = name
-
-    def verify(self, frame):
-        pass
 
 
 
@@ -173,9 +164,6 @@ class Declare(Stmt):
         self.name = name
         self.type = type
 
-    def verify(self, frame):
-        pass
-
 
 
 class Assign(Stmt):
@@ -184,9 +172,6 @@ class Assign(Stmt):
         self.rule = rule
         self.name = name
         self.expr = expr
-
-    def verify(self, frame):
-        pass
 
 
 
@@ -198,9 +183,6 @@ class Conditional(Stmt):
         self.stmtMap = stmtMap
         self.fallback = fallback
 
-    def verify(self, frame):
-        pass
-
 
 
 class Loop(Stmt):
@@ -210,9 +192,6 @@ class Loop(Stmt):
         self.init = init
         self.cond = cond
         self.stmts = stmts
-
-    def verify(self, frame):
-        pass
 
 
 
@@ -226,9 +205,6 @@ class Callable(Stmt):
         self.stmts = stmts
         self.returnType = returnType
 
-    def verify(self, frame):
-        pass
-
 
 
 class Calling(Stmt):
@@ -240,9 +216,6 @@ class Calling(Stmt):
         self.callable = callable
         self.args = args
 
-    def verify(self, frame):
-        pass
-
 
 
 class Return(Stmt):
@@ -250,9 +223,6 @@ class Return(Stmt):
     def __init__(self, rule, expr):
         self.rule = rule
         self.expr = expr
-
-    def verify(self, frame):
-        pass
 
 
 
@@ -264,6 +234,3 @@ class File(Stmt):
         self.name = name
         self.mode = mode
         self.data = data
-
-    def verify(self, frame):
-        pass

--- a/main.pseudo
+++ b/main.pseudo
@@ -1,10 +1,7 @@
 DECLARE Number : INTEGER
 DECLARE Max : INTEGER
-Number <- 0
-Max <- 10
 OPENFILE "data.txt" FOR WRITE
-WHILE Number <= Max DO
+FOR Number <- 0 TO 10
     WRITEFILE "data.txt", Number
-    Number <- Number + 1
-ENDWHILE
+ENDFOR
 CLOSEFILE "data.txt"

--- a/main.pseudo
+++ b/main.pseudo
@@ -1,7 +1,10 @@
-DECLARE Number : INTEGER
-DECLARE Max : INTEGER
-OPENFILE "data.txt" FOR WRITE
-FOR Number <- 0 TO 10
-    WRITEFILE "data.txt", Number
-ENDFOR
-CLOSEFILE "data.txt"
+PROCEDURE WriteNumber(Start : INTEGER, End : INTEGER)
+    DECLARE Number : INTEGER
+    OPENFILE "data.txt" FOR WRITE
+    FOR Number <- Start TO End
+        WRITEFILE "data.txt", Number
+    ENDFOR
+    CLOSEFILE "data.txt"
+ENDPROCEDURE
+
+CALL WriteNumber(1, 10)

--- a/parser.py
+++ b/parser.py
@@ -272,12 +272,12 @@ def forStmt(tokens):
     # Initialise name to start
     init = Assign('assign', name, start)
     # Generate loop cond
-    cond = Binary(makeExpr(frame=None, name=name), lte, end)
+    cond = Binary(makeExpr(frame=NULL, name=name), lte, end)
     # Add increment statement
     incr = Assign(
         'assign',
         name,
-        Binary(makeExpr(frame=None, name=name), add, step),
+        Binary(makeExpr(frame=NULL, name=name), add, step),
     )
     return Loop('while', init, cond, stmts + [incr])
 

--- a/parser.py
+++ b/parser.py
@@ -300,7 +300,7 @@ def procedureStmt(tokens):
     if match(tokens, '('):
         passby = makeToken(name['line'], name['col'], 'keyword', 'BYVALUE', None)
         if check(tokens)['word'] in ('BYVALUE', 'BYREF'):
-            passby = consume(tokens)
+            passby = consume(tokens)['word']
         var = declare(tokens)
         params += [var]
         while match(tokens, ','):
@@ -332,7 +332,7 @@ def functionStmt(tokens):
     name = identifier(tokens)
     params = []
     if match(tokens, '('):
-        passby = makeToken(name['line'], name['col'], 'keyword', 'BYVALUE', None)
+        passby = 'BYVALUE'
         var = declare(tokens)
         params += [var]
         while match(tokens, ','):

--- a/parser.py
+++ b/parser.py
@@ -285,7 +285,7 @@ def procedureStmt(tokens):
     name = identifier(tokens)
     params = []
     if match(tokens, '('):
-        passby = makeToken(None, None, 'keyword', 'BYVALUE', None)
+        passby = 'BYVALUE'
         if check(tokens)['word'] in ('BYVALUE', 'BYREF'):
             passby = consume(tokens)['word']
         var = declare(tokens)

--- a/parser.py
+++ b/parser.py
@@ -268,7 +268,6 @@ def forStmt(tokens):
     stmts = []
     while not atEnd(tokens) and not match(tokens, 'ENDFOR'):
         stmts += [statement(tokens)]
-    expectElseError(tokens, 'ENDFOR', "at end of FOR")
     expectElseError(tokens, '\n', "after ENDFOR")
     # Initialise name to start
     init = assignStmt([
@@ -311,7 +310,6 @@ def procedureStmt(tokens):
     stmts = []
     while not atEnd(tokens) and not match(tokens, 'ENDPROCEDURE'):
         stmts += [statement(tokens)]
-    expectElseError(tokens, 'ENDPROCEDURE', "at end of PROCEDURE")
     expectElseError(tokens, '\n', "after ENDPROCEDURE")
     return Callable('procedure', name, passby, params, stmts, None)
 

--- a/parser.py
+++ b/parser.py
@@ -303,16 +303,7 @@ def procedureStmt(tokens):
 
 def callStmt(tokens):
     callable = value(tokens)
-    args = []
-    if match(tokens, '('):
-        arg = expression(tokens)
-        args += [arg]
-        while match(tokens, ','):
-            arg = expression(tokens)
-            args += [arg]
-        expectElseError(tokens, ')', "after arguments")
-    expectElseError(tokens, '\n', "at end of CALL")
-    return Calling('call', callable, args)
+    return Calling('call', callable)
 
 def functionStmt(tokens):
     name = identifier(tokens)

--- a/parser.py
+++ b/parser.py
@@ -182,7 +182,7 @@ def declare(tokens):
         raise ParseError("Invalid type", typetoken)
     var = {
         'name': name,
-        'type': typetoken,
+        'type': typetoken['word'],
     }
     return var
     
@@ -360,7 +360,7 @@ def openfileStmt(tokens):
     expectElseError(tokens, 'FOR', "after file identifier")
     if check(tokens)['word'] not in ('READ', 'WRITE', 'APPEND'):
         raise ParseError("Invalid file mode", check(tokens))
-    mode = consume(tokens)
+    mode = consume(tokens)['word']
     expectElseError(tokens, '\n')
     return File('file', 'open', name, mode, None)
 

--- a/parser.py
+++ b/parser.py
@@ -3,6 +3,8 @@ from builtin import ParseError
 from builtin import lte, add
 from scanner import makeToken
 from lang import Literal, Name, Unary, Binary, Get, Call
+from lang import Output, Input, Declare, Assign, Conditional, Loop
+from lang import Callable, Return, File
 
 
 

--- a/parser.py
+++ b/parser.py
@@ -270,34 +270,22 @@ def forStmt(tokens):
         stmts += [statement(tokens)]
     expectElseError(tokens, '\n', "after ENDFOR")
     # Initialise name to start
-    init = assignStmt([
-        name,
-        makeToken(name['line'], name['col'], 'keyword', '<-', None),
-        start,
-        makeToken(end['line'], end['col'], 'keyword', '\n', None),
-    ])
+    init = Assign('assign', name, start)
     # Generate loop cond
-    cond = makeExpr(
-        left=makeExpr(frame=None, name=name),
-        oper=lte,
-        right=end,
-    )
+    cond = Binary(makeExpr(frame=None, name=name), lte, end)
     # Add increment statement
-    incr = assignStmt([
+    incr = Assign(
+        'assign',
         name,
-        makeToken(name['line'], name['col'], 'keyword', '<-', None),
-        name,
-        makeToken(name['line'], name['col'], 'keyword', '+', add),
-        step,
-        makeToken(end['line'], name['col'], 'keyword', '\n', None),
-    ])
+        Binary(makeExpr(frame=None, name=name), add, step),
+    )
     return Loop('while', init, cond, stmts + [incr])
 
 def procedureStmt(tokens):
     name = identifier(tokens)
     params = []
     if match(tokens, '('):
-        passby = makeToken(name['line'], name['col'], 'keyword', 'BYVALUE', None)
+        passby = makeToken(None, None, 'keyword', 'BYVALUE', None)
         if check(tokens)['word'] in ('BYVALUE', 'BYREF'):
             passby = consume(tokens)['word']
         var = declare(tokens)

--- a/resolver.py
+++ b/resolver.py
@@ -39,7 +39,7 @@ def verifyInput(frame, stmt):
     if name not in frame:
         raise LogicError(
             f'Name not declared',
-            stmt.name.resolve(frame),
+            stmt.name,
         )
 
 def verifyDeclare(frame, stmt):

--- a/resolver.py
+++ b/resolver.py
@@ -80,7 +80,8 @@ def verifyProcedure(frame, stmt):
             # Reference frame vars in local
             local[name] = frame[name]
         else:
-            verifyDeclare(local, var)
+            name = var['name'].resolve(frame)
+            frame[name] = {'type': var['type'], 'value': None}
     # Resolve procedure statements using local
     verifyStmts(local, stmt.stmts)
     # Declare procedure in frame

--- a/resolver.py
+++ b/resolver.py
@@ -54,7 +54,7 @@ def verifyCase(frame, stmt):
     stmt.cond.resolve(frame)
     verifyStmts(frame, stmt.stmts.values())
     if stmt.fallback:
-        stmt.fallback.verify(frame)
+        stmt.fallback.accept(frame, verify)
 
 def verifyIf(frame, stmt):
     stmt.cond.resolve(frame)
@@ -132,13 +132,13 @@ def verifyFunction(frame, stmt):
         # Declare vars in local
         verifyDeclare(local, var)
     name = stmt.name.resolve(frame)
-    returns = stmt.returns
+    returnType = stmt.returnType
     # Resolve procedure statements using local
     for procstmt in stmt.stmts:
-        returntype = procstmt.verify(local)
-        if returntype and (returntype != returns):
+        stmtType = procstmt.accept(local, verify)
+        if stmtType and (stmtType != returnType):
             raise LogicError(
-                f"Expect {returns}, got {returntype}",
+                f"Expect {returnType}, got {stmtType}",
                 stmt.name,
             )
     # Declare function in frame

--- a/resolver.py
+++ b/resolver.py
@@ -73,6 +73,7 @@ def verifyWhile(frame, stmt):
 def verifyProcedure(frame, stmt):
     # Set up local frame
     local = {}
+    breakpoint()
     for var in stmt.params:
         if stmt.passby == 'BYREF':
             name = var['name'].resolve(frame)
@@ -81,7 +82,7 @@ def verifyProcedure(frame, stmt):
             local[name] = frame[name]
         else:
             name = var['name'].resolve(frame)
-            frame[name] = {'type': var['type'], 'value': None}
+            local[name] = {'type': var['type'], 'value': None}
     # Resolve procedure statements using local
     verifyStmts(local, stmt.stmts)
     # Declare procedure in frame

--- a/resolver.py
+++ b/resolver.py
@@ -116,11 +116,10 @@ def verifyCall(frame, stmt):
     for arg, param in zip(args, params):
         if stmt.passby == 'BYREF':
             # Only names allowed for BYREF arguments
-            # Check for a get expr
-            if arg['oper']['value'] is not get:
+            if not isinstance(arg, Get):
                 raise LogicError(
                     'BYREF arg must be a name, not expression',
-                    stmt.passby,
+                    None,
                 )
         paramtype = param['type']
         expectTypeElseError(frame, arg, paramtype)

--- a/resolver.py
+++ b/resolver.py
@@ -76,10 +76,9 @@ def verifyProcedure(frame, stmt):
     for var in stmt.params:
         if stmt.passby == 'BYREF':
             name = var['name'].resolve(frame)
-            globvar = frame[name]
-            expectTypeElseError(frame, var['type'], globvar['type'])
-            # Reference global vars in local
-            local[name] = globvar
+            expectTypeElseError(frame, var['type'], frame[name]['type'])
+            # Reference frame vars in local
+            local[name] = frame[name]
         else:
             verifyDeclare(local, var)
     # Resolve procedure statements using local

--- a/resolver.py
+++ b/resolver.py
@@ -32,49 +32,49 @@ def verifyStmts(frame, stmts):
         stmt.verify(frame)
 
 def verifyOutput(frame, stmt):
-    resolveExprs(frame, stmt['exprs'])
+    resolveExprs(frame, stmt.exprs)
 
 def verifyInput(frame, stmt):
-    name = stmt['name'].resolve(frame)
+    name = stmt.name.resolve(frame)
     if name not in frame:
         raise LogicError(
             f'Name not declared',
-            stmt['name'].resolve(frame),
+            stmt.name.resolve(frame),
         )
 
 def verifyDeclare(frame, stmt):
-    name = stmt['name'].resolve(frame)
-    frame[name] = {'type': stmt['type'], 'value': None}
+    name = stmt.name.resolve(frame)
+    frame[name] = {'type': stmt.type, 'value': None}
 
 def verifyAssign(frame, stmt):
-    name = stmt['name'].resolve(frame)
-    expectTypeElseError(frame, stmt['expr'], frame[name]['type'])
+    name = stmt.name.resolve(frame)
+    expectTypeElseError(frame, stmt.expr, frame[name]['type'])
 
 def verifyCase(frame, stmt):
-    stmt['cond'].resolve(frame)
-    verifyStmts(frame, stmt['stmts'].values())
-    if stmt['fallback']:
-        stmt['fallback'].verify(frame)
+    stmt.cond.resolve(frame)
+    verifyStmts(frame, stmt.stmts.values())
+    if stmt.fallback:
+        stmt.fallback.verify(frame)
 
 def verifyIf(frame, stmt):
-    stmt['cond'].resolve(frame)
-    expectTypeElseError(frame, stmt['cond'], 'BOOLEAN')
-    verifyStmts(frame, stmt['stmts'][True])
-    if stmt['fallback']:
-        verifyStmts(frame, stmt['fallback'])
+    stmt.cond.resolve(frame)
+    expectTypeElseError(frame, stmt.cond, 'BOOLEAN')
+    verifyStmts(frame, stmt.stmts[True])
+    if stmt.fallback:
+        verifyStmts(frame, stmt.fallback)
 
 def verifyWhile(frame, stmt):
-    if stmt['init']:
-        stmt['init'].verify(frame)
-    stmt['cond'].resolve(frame)
-    expectTypeElseError(frame, stmt['cond'], 'BOOLEAN')
-    verifyStmts(frame, stmt['stmts'])
+    if stmt.init:
+        stmt.init.verify(frame)
+    stmt.cond.resolve(frame)
+    expectTypeElseError(frame, stmt.cond, 'BOOLEAN')
+    verifyStmts(frame, stmt.stmts)
 
 def verifyProcedure(frame, stmt):
-    passby = stmt['passby']
+    passby = stmt.passby
     # Set up local frame
     local = {}
-    for var in stmt['params']:
+    for var in stmt.params:
         # Declare vars in local
         if passby == 'BYVALUE':
             verifyDeclare(local, var)
@@ -86,41 +86,41 @@ def verifyProcedure(frame, stmt):
             local[name] = globvar
         else:
             # Internal error
-            raise TypeError(stmt['passby'], f"str expected for passby, got {passby}")
+            raise TypeError(stmt.passby, f"str expected for passby, got {passby}")
     # Resolve procedure statements using local
-    verifyStmts(local, stmt['stmts'])
+    verifyStmts(local, stmt.stmts)
     # Declare procedure in frame
-    name = stmt['name'].resolve(frame)
+    name = stmt.name.resolve(frame)
     frame[name] = {
         'type': 'procedure',
         'value': {
             'frame': local,
             'passby': passby,
-            'params': stmt['params'],
-            'stmts': stmt['stmts'],
+            'params': stmt.params,
+            'stmts': stmt.stmts,
         }
     }
 
 def verifyCall(frame, stmt):
-    name = stmt['name'].resolve(frame)
+    name = stmt.name.resolve(frame)
     proc = frame[name]
     expectTypeElseError(frame, proc, 'procedure')
-    args, params = stmt['args'], proc['value']['params']
+    args, params = stmt.args, proc['value']['params']
     if len(args) != len(params):
         raise LogicError(
             f'Expected {len(params)} args, got {len(args)}',
-            stmt['name']['right'],
+            None,
         )
     # Type-check arguments
     local = proc['value']['frame']
     for arg, param in zip(args, params):
-        if stmt['passby'] == 'BYREF':
+        if stmt.passby == 'BYREF':
             # Only names allowed for BYREF arguments
             # Check for a get expr
             if arg['oper']['value'] is not get:
                 raise LogicError(
                     'BYREF arg must be a name, not expression',
-                    stmt['passby'],
+                    stmt.passby,
                 )
         paramtype = param['type']
         expectTypeElseError(frame, arg, paramtype)
@@ -128,18 +128,18 @@ def verifyCall(frame, stmt):
 def verifyFunction(frame, stmt):
     # Set up local frame
     local = {}
-    for var in stmt['params']:
+    for var in stmt.params:
         # Declare vars in local
         verifyDeclare(local, var)
-    name = stmt['name'].resolve(frame)
-    returns = stmt['returns'].resolve(frame)
+    name = stmt.name.resolve(frame)
+    returns = stmt.returns
     # Resolve procedure statements using local
-    for procstmt in stmt['stmts']:
+    for procstmt in stmt.stmts:
         returntype = procstmt.verify(local)
         if returntype and (returntype != returns):
             raise LogicError(
                 f"Expect {returns}, got {returntype}",
-                stmt['name'],
+                stmt.name,
             )
     # Declare function in frame
     frame[name] = {
@@ -147,8 +147,8 @@ def verifyFunction(frame, stmt):
         'value': {
             'frame': local,
             'passby': 'BYVALUE',
-            'params': stmt['params'],
-            'stmts': stmt['stmts'],
+            'params': stmt.params,
+            'stmts': stmt.stmts,
         }
     }
 
@@ -156,58 +156,58 @@ def verifyReturn(local, stmt):
     # This will typically be verify()ed within
     # verifyFunction(), so frame is expected to
     # be local
-    return stmt['expr'].resolve(local)
+    return stmt.expr.resolve(local)
 
 def verifyFile(frame, stmt):
-    name = stmt['name'].resolve(frame)
-    if stmt['action'] == 'open':
+    name = stmt.name.resolve(frame)
+    if stmt.action == 'open':
         if name in frame:
-            raise LogicError("File already opened", stmt['name'])
-        file = {'type': stmt['mode'], 'value': None}
+            raise LogicError("File already opened", stmt.name)
+        file = {'type': stmt.mode, 'value': None}
         frame[name] = file
-    elif stmt['action'] == 'read':
+    elif stmt.action == 'read':
         if name not in frame:
-            raise LogicError("File not open", stmt['name'])
+            raise LogicError("File not open", stmt.name)
         file = frame[name]
         if file['type'] != 'READ':
-            raise LogicError("File mode is {file['type']}", stmt['name'])
-    elif stmt['action'] == 'write':
-        stmt['data'].resolve(frame)
+            raise LogicError("File mode is {file['type']}", stmt.name)
+    elif stmt.action == 'write':
+        stmt.data.resolve(frame)
         if name not in frame:
-            raise LogicError("File not open", stmt['name'])
+            raise LogicError("File not open", stmt.name)
         file = frame[name]
         if file['type'] not in ('WRITE', 'APPEND'):
-            raise LogicError("File mode is {file['type']}", stmt['name'])
-    elif stmt['action'] == 'close':
+            raise LogicError("File mode is {file['type']}", stmt.name)
+    elif stmt.action == 'close':
         if name not in frame:
-            raise LogicError("File not open", stmt['name'])
+            raise LogicError("File not open", stmt.name)
         del frame[name]
 
 def verify(frame, stmt):
     if 'rule' not in stmt: breakpoint()
-    if stmt['rule'] == 'output':
+    if stmt.rule == 'output':
         verifyOutput(frame, stmt)
-    if stmt['rule'] == 'input':
+    if stmt.rule == 'input':
         verifyInput(frame, stmt)
-    elif stmt['rule'] == 'declare':
+    elif stmt.rule == 'declare':
         verifyDeclare(frame, stmt)
-    elif stmt['rule'] == 'assign':
+    elif stmt.rule == 'assign':
         verifyAssign(frame, stmt)
-    elif stmt['rule'] == 'case':
+    elif stmt.rule == 'case':
         verifyCase(frame, stmt)
-    elif stmt['rule'] == 'if':
+    elif stmt.rule == 'if':
         verifyIf(frame, stmt)
-    elif stmt['rule'] in ('while', 'repeat'):
+    elif stmt.rule in ('while', 'repeat'):
         verifyWhile(frame, stmt)
-    elif stmt['rule'] == 'procedure':
+    elif stmt.rule == 'procedure':
         verifyProcedure(frame, stmt)
-    elif stmt['rule'] == 'call':
+    elif stmt.rule == 'call':
         verifyCall(frame, stmt)
-    elif stmt['rule'] == 'function':
+    elif stmt.rule == 'function':
         verifyFunction(frame, stmt)
-    elif stmt['rule'] == 'file':
+    elif stmt.rule == 'file':
         verifyFile(frame, stmt)
-    elif stmt['rule'] == 'return':
+    elif stmt.rule == 'return':
         return verifyReturn(frame, stmt)
 
 def inspect(statements):

--- a/resolver.py
+++ b/resolver.py
@@ -2,6 +2,7 @@ from builtin import get, call
 from builtin import lt, lte, gt, gte, ne, eq
 from builtin import add, sub, mul, div
 from builtin import LogicError
+from lang import Get
 
 
 
@@ -100,15 +101,14 @@ def verifyCall(frame, stmt):
     stmt.callable.resolve(frame)
     proc = stmt.callable.callable.evaluate(frame)
     expectTypeElseError(frame, stmt.callable, 'procedure')
-    args, params = stmt.args, proc['value']['params']
-    if len(args) != len(params):
+    if len(stmt.args) != len(proc['params']):
         raise LogicError(
-            f'Expected {len(params)} args, got {len(args)}',
+            f"Expected {len(proc['params'])} args, got {len(stmt.args)}",
             None,
         )
     # Type-check arguments
-    local = proc['value']['frame']
-    for arg, param in zip(args, params):
+    local = proc['frame']
+    for arg, param in zip(stmt.args, proc['params']):
         if stmt.passby == 'BYREF':
             arg.resolve(frame)
             # Only names allowed for BYREF arguments

--- a/resolver.py
+++ b/resolver.py
@@ -29,7 +29,7 @@ def resolveExprs(frame, exprs):
 
 def verifyStmts(frame, stmts):
     for stmt in stmts:
-        verify(frame, stmt)
+        stmt.verify(frame)
 
 def verifyOutput(frame, stmt):
     resolveExprs(frame, stmt['exprs'])
@@ -54,7 +54,7 @@ def verifyCase(frame, stmt):
     stmt['cond'].resolve(frame)
     verifyStmts(frame, stmt['stmts'].values())
     if stmt['fallback']:
-        verify(frame, stmt['fallback'])
+        stmt['fallback'].verify(frame)
 
 def verifyIf(frame, stmt):
     stmt['cond'].resolve(frame)
@@ -65,7 +65,7 @@ def verifyIf(frame, stmt):
 
 def verifyWhile(frame, stmt):
     if stmt['init']:
-        verify(frame, stmt['init'])
+        stmt['init'].verify(frame)
     stmt['cond'].resolve(frame)
     expectTypeElseError(frame, stmt['cond'], 'BOOLEAN')
     verifyStmts(frame, stmt['stmts'])
@@ -135,7 +135,7 @@ def verifyFunction(frame, stmt):
     returns = stmt['returns'].resolve(frame)
     # Resolve procedure statements using local
     for procstmt in stmt['stmts']:
-        returntype = verify(local, procstmt)
+        returntype = procstmt.verify(local)
         if returntype and (returntype != returns):
             raise LogicError(
                 f"Expect {returns}, got {returntype}",

--- a/resolver.py
+++ b/resolver.py
@@ -71,7 +71,7 @@ def verifyWhile(frame, stmt):
     verifyStmts(frame, stmt['stmts'])
 
 def verifyProcedure(frame, stmt):
-    passby = stmt['passby']['word']
+    passby = stmt['passby']
     # Set up local frame
     local = {}
     for var in stmt['params']:
@@ -114,7 +114,7 @@ def verifyCall(frame, stmt):
     # Type-check arguments
     local = proc['value']['frame']
     for arg, param in zip(args, params):
-        if stmt['passby']['word'] == 'BYREF':
+        if stmt['passby'] == 'BYREF':
             # Only names allowed for BYREF arguments
             # Check for a get expr
             if arg['oper']['value'] is not get:
@@ -122,7 +122,7 @@ def verifyCall(frame, stmt):
                     'BYREF arg must be a name, not expression',
                     stmt['passby'],
                 )
-        paramtype = param['type']['word']
+        paramtype = param['type']
         expectTypeElseError(frame, arg, paramtype)
 
 def verifyFunction(frame, stmt):

--- a/resolver.py
+++ b/resolver.py
@@ -115,12 +115,15 @@ def verifyCall(frame, stmt):
     local = proc['value']['frame']
     for arg, param in zip(args, params):
         if stmt.passby == 'BYREF':
+            arg.resolve(frame)
             # Only names allowed for BYREF arguments
             if not isinstance(arg, Get):
                 raise LogicError(
                     'BYREF arg must be a name, not expression',
                     None,
                 )
+        else:
+            arg.resolve(local)
         paramtype = param['type']
         expectTypeElseError(frame, arg, paramtype)
 

--- a/resolver.py
+++ b/resolver.py
@@ -71,22 +71,17 @@ def verifyWhile(frame, stmt):
     verifyStmts(frame, stmt.stmts)
 
 def verifyProcedure(frame, stmt):
-    passby = stmt.passby
     # Set up local frame
     local = {}
     for var in stmt.params:
-        # Declare vars in local
-        if passby == 'BYVALUE':
-            verifyDeclare(local, var)
-        elif passby == 'BYREF':
+        if stmt.passby == 'BYREF':
             name = var['name'].resolve(frame)
             globvar = frame[name]
             expectTypeElseError(frame, var['type'], globvar['type'])
             # Reference global vars in local
             local[name] = globvar
         else:
-            # Internal error
-            raise TypeError(stmt.passby, f"str expected for passby, got {passby}")
+            verifyDeclare(local, var)
     # Resolve procedure statements using local
     verifyStmts(local, stmt.stmts)
     # Declare procedure in frame

--- a/resolver.py
+++ b/resolver.py
@@ -29,7 +29,7 @@ def resolveExprs(frame, exprs):
 
 def verifyStmts(frame, stmts):
     for stmt in stmts:
-        stmt.verify(frame)
+        stmt.accept(frame, verify)
 
 def verifyOutput(frame, stmt):
     resolveExprs(frame, stmt.exprs)
@@ -186,29 +186,29 @@ def verifyFile(frame, stmt):
 def verify(frame, stmt):
     if 'rule' not in stmt: breakpoint()
     if stmt.rule == 'output':
-        verifyOutput(frame, stmt)
+        stmt.accept(frame, verifyOutput)
     if stmt.rule == 'input':
-        verifyInput(frame, stmt)
+        stmt.accept(frame, verifyInput)
     elif stmt.rule == 'declare':
-        verifyDeclare(frame, stmt)
+        stmt.accept(frame, verifyDeclare)
     elif stmt.rule == 'assign':
-        verifyAssign(frame, stmt)
+        stmt.accept(frame, verifyAssign)
     elif stmt.rule == 'case':
-        verifyCase(frame, stmt)
+        stmt.accept(frame, verifyCase)
     elif stmt.rule == 'if':
-        verifyIf(frame, stmt)
-    elif stmt.rule in ('while', 'repeat'):
-        verifyWhile(frame, stmt)
+        stmt.accept(frame, verifyIf)
+    elif stmt.rule in ('while', 'repeat', 'for'):
+        stmt.accept(frame, verifyWhile)
     elif stmt.rule == 'procedure':
-        verifyProcedure(frame, stmt)
+        stmt.accept(frame, verifyProcedure)
     elif stmt.rule == 'call':
-        verifyCall(frame, stmt)
+        stmt.accept(frame, verifyCall)
     elif stmt.rule == 'function':
-        verifyFunction(frame, stmt)
+        stmt.accept(frame, verifyFunction)
     elif stmt.rule == 'file':
-        verifyFile(frame, stmt)
+        stmt.accept(frame, verifyFile)
     elif stmt.rule == 'return':
-        return verifyReturn(frame, stmt)
+        return stmt.accept(frame, verifyReturn)
 
 def inspect(statements):
     frame = {}

--- a/resolver.py
+++ b/resolver.py
@@ -11,13 +11,13 @@ def expectTypeElseError(frame, expr, expected):
     exprtype = expr.resolve(frame)
     if expected != exprtype:
         token = None
-        if type(expr) is dict:
-            if 'line' in expr:
-                token = expr
-            elif 'line' in expr['left']:
-                token = expr['left']
-            elif 'line' in expr['right']:
-                token = expr['right']
+        # if type(expr) is dict:
+        #     if 'line' in expr:
+        #         token = expr
+        #     elif 'line' in expr['left']:
+        #         token = expr['left']
+        #     elif 'line' in expr['right']:
+        #         token = expr['right']
         raise LogicError(
             f"Expected {repr(expected)}, got {repr(exprtype)}",
             token,

--- a/resolver.py
+++ b/resolver.py
@@ -130,7 +130,7 @@ def verifyFunction(frame, stmt):
     name = stmt.name.resolve(frame)
     returnType = stmt.returnType
     # Resolve procedure statements using local
-    hasReturn = True
+    hasReturn = False
     for procstmt in stmt.stmts:
         stmtType = procstmt.accept(local, verify)
         if stmtType:

--- a/resolver.py
+++ b/resolver.py
@@ -31,49 +31,6 @@ def verifyStmts(frame, stmts):
     for stmt in stmts:
         verify(frame, stmt)
 
-def resolve(frame, expr):
-    # Resolving tokens
-    if 'type' in expr:
-        if expr['type'] == 'name':
-            return expr['word']
-        elif expr['type'] in ('integer', 'string'):
-            return expr['type'].upper()
-        else:
-            # internal error
-            raise TypeError(f'Cannot resolve type for {expr}')
-    # Resolving get expressions
-    oper = expr['oper']['value']
-    if oper is get:
-        expr['left'] = frame
-        name = resolve(frame, expr['right'])
-        if name not in frame:
-            raise LogicError(
-                f'Name not declared',
-                expr['right'],
-            )
-        return frame[name]['type']
-    # Resolving function calls
-    if oper is call:
-        # Insert frame into get expr
-        resolve(frame, expr['left'])
-        # Insert frame into args
-        args = expr['right']
-        resolveExprs(frame, args)
-        # Return function type
-        functype = resolve(frame, expr['left'])
-        return functype
-    # Resolving other exprs
-    if oper in (lt, lte, gt, gte, ne, eq):
-        resolve(frame, expr['left'])
-        resolve(frame, expr['right'])
-        return 'BOOLEAN'
-    elif oper in (add, sub, mul, div):
-        resolve(frame, expr['left'])
-        resolve(frame, expr['right'])
-        expectTypeElseError(frame, expr['left'], 'INTEGER')
-        expectTypeElseError(frame, expr['right'], 'INTEGER')
-        return 'INTEGER'
-
 def verifyOutput(frame, stmt):
     resolveExprs(frame, stmt['exprs'])
 

--- a/resolver.py
+++ b/resolver.py
@@ -98,9 +98,8 @@ def verifyProcedure(frame, stmt):
 
 def verifyCall(frame, stmt):
     stmt.callable.resolve(frame)
-    breakpoint()
     proc = stmt.callable.callable.evaluate(frame)
-    expectTypeElseError(frame, proc, 'procedure')
+    expectTypeElseError(frame, stmt.callable, 'procedure')
     args, params = stmt.args, proc['value']['params']
     if len(args) != len(params):
         raise LogicError(

--- a/resolver.py
+++ b/resolver.py
@@ -65,7 +65,7 @@ def verifyIf(frame, stmt):
 
 def verifyWhile(frame, stmt):
     if stmt.init:
-        stmt.init.verify(frame)
+        stmt.init.accept(frame, verify)
     stmt.cond.resolve(frame)
     expectTypeElseError(frame, stmt.cond, 'BOOLEAN')
     verifyStmts(frame, stmt.stmts)

--- a/resolver.py
+++ b/resolver.py
@@ -89,7 +89,7 @@ def verifyProcedure(frame, stmt):
         'type': 'procedure',
         'value': {
             'frame': local,
-            'passby': passby,
+            'passby': stmt.passby,
             'params': stmt.params,
             'stmts': stmt.stmts,
         }

--- a/resolver.py
+++ b/resolver.py
@@ -185,7 +185,6 @@ def verifyFile(frame, stmt):
         del frame[name]
 
 def verify(frame, stmt):
-    if 'rule' not in stmt: breakpoint()
     if stmt.rule == 'output':
         stmt.accept(frame, verifyOutput)
     if stmt.rule == 'input':

--- a/resolver.py
+++ b/resolver.py
@@ -73,7 +73,6 @@ def verifyWhile(frame, stmt):
 def verifyProcedure(frame, stmt):
     # Set up local frame
     local = {}
-    breakpoint()
     for var in stmt.params:
         if stmt.passby == 'BYREF':
             name = var['name'].resolve(frame)
@@ -98,7 +97,8 @@ def verifyProcedure(frame, stmt):
     }
 
 def verifyCall(frame, stmt):
-    name = stmt.name.resolve(frame)
+    stmt.callable.resolve(frame)
+    name = stmt.callable.evaluate(frame)
     proc = frame[name]
     expectTypeElseError(frame, proc, 'procedure')
     args, params = stmt.args, proc['value']['params']

--- a/resolver.py
+++ b/resolver.py
@@ -101,26 +101,26 @@ def verifyCall(frame, stmt):
     stmt.callable.resolve(frame)
     proc = stmt.callable.callable.evaluate(frame)
     expectTypeElseError(frame, stmt.callable, 'procedure')
-    if len(stmt.args) != len(proc['params']):
-        raise LogicError(
-            f"Expected {len(proc['params'])} args, got {len(stmt.args)}",
-            None,
-        )
-    # Type-check arguments
-    local = proc['frame']
-    for arg, param in zip(stmt.args, proc['params']):
-        if stmt.passby == 'BYREF':
-            arg.resolve(frame)
-            # Only names allowed for BYREF arguments
-            if not isinstance(arg, Get):
-                raise LogicError(
-                    'BYREF arg must be a name, not expression',
-                    None,
-                )
-        else:
-            arg.resolve(local)
-        paramtype = param['type']
-        expectTypeElseError(frame, arg, paramtype)
+    # if len(stmt.args) != len(proc['params']):
+    #     raise LogicError(
+    #         f"Expected {len(proc['params'])} args, got {len(stmt.args)}",
+    #         None,
+    #     )
+    # # Type-check arguments
+    # local = proc['frame']
+    # for arg, param in zip(stmt.args, proc['params']):
+    #     if stmt.passby == 'BYREF':
+    #         arg.resolve(frame)
+    #         # Only names allowed for BYREF arguments
+    #         if not isinstance(arg, Get):
+    #             raise LogicError(
+    #                 'BYREF arg must be a name, not expression',
+    #                 None,
+    #             )
+    #     else:
+    #         arg.resolve(local)
+    #     paramtype = param['type']
+    #     expectTypeElseError(frame, arg, paramtype)
 
 def verifyFunction(frame, stmt):
     # Set up local frame

--- a/resolver.py
+++ b/resolver.py
@@ -39,13 +39,12 @@ def verifyInput(frame, stmt):
     if name not in frame:
         raise LogicError(
             f'Name not declared',
-            stmt['name'].name,
+            stmt['name'].resolve(frame),
         )
 
 def verifyDeclare(frame, stmt):
     name = stmt['name'].resolve(frame)
-    type_ = stmt['type']['word']
-    frame[name] = {'type': type_, 'value': None}
+    frame[name] = {'type': stmt['type'], 'value': None}
 
 def verifyAssign(frame, stmt):
     name = stmt['name'].resolve(frame)
@@ -164,7 +163,7 @@ def verifyFile(frame, stmt):
     if stmt['action'] == 'open':
         if name in frame:
             raise LogicError("File already opened", stmt['name'])
-        file = {'type': stmt['mode']['word'], 'value': None}
+        file = {'type': stmt['mode'], 'value': None}
         frame[name] = file
     elif stmt['action'] == 'read':
         if name not in frame:

--- a/resolver.py
+++ b/resolver.py
@@ -98,8 +98,8 @@ def verifyProcedure(frame, stmt):
 
 def verifyCall(frame, stmt):
     stmt.callable.resolve(frame)
-    name = stmt.callable.evaluate(frame)
-    proc = frame[name]
+    breakpoint()
+    proc = stmt.callable.callable.evaluate(frame)
     expectTypeElseError(frame, proc, 'procedure')
     args, params = stmt.args, proc['value']['params']
     if len(args) != len(params):

--- a/resolver.py
+++ b/resolver.py
@@ -136,16 +136,21 @@ def verifyFunction(frame, stmt):
     name = stmt.name.resolve(frame)
     returnType = stmt.returnType
     # Resolve procedure statements using local
+    hasReturn = True
     for procstmt in stmt.stmts:
         stmtType = procstmt.accept(local, verify)
-        if stmtType and (stmtType != returnType):
+        if stmtType:
+            hasReturn = True
+            if stmtType != returnType:
             raise LogicError(
                 f"Expect {returnType}, got {stmtType}",
                 stmt.name,
             )
+    if not hasReturn:
+        raise LogicError("No RETURN in function, None)
     # Declare function in frame
     frame[name] = {
-        'type': returns,
+        'type': returnType,
         'value': {
             'frame': local,
             'passby': 'BYVALUE',

--- a/resolver.py
+++ b/resolver.py
@@ -136,13 +136,13 @@ def verifyFunction(frame, stmt):
         if stmtType:
             hasReturn = True
             if stmtType != returnType:
-            raise LogicError(
-                f"Expect {returnType}, got {stmtType}",
-                stmt.name,
-            )
+                raise LogicError(
+                    f"Expect {returnType}, got {stmtType}",
+                    stmt.name,
+                )
     if not hasReturn:
-        raise LogicError("No RETURN in function, None)
-    # Declare function in frame
+        raise LogicError("No RETURN in function", None)
+     # Declare function in frame
     frame[name] = {
         'type': returnType,
         'value': {


### PR DESCRIPTION
You've seen, in [OOP: Expressions](https://github.com/nyjc-computing/pseudo/pull/34), how OOP can help us simplify our code so that we don't need lots of `if-else` statements to handle different expression types.

Let's extend those benefits to statements, starting with a `Stmt` parent class:
https://github.com/nyjc-computing/pseudo/blob/3e652633ef91caaa2f3f7f2aa96cb6f7515a4c49/lang.py#L130-L141

A `Stmt` class has a `verify()` method for resolving, and an `execute()` method for interpreting.