### PR TITLE
16c OOP: Expression Statements

### DIFF
--- a/builtin.py
+++ b/builtin.py
@@ -66,12 +66,6 @@ def ne(x, y):
 def eq(x, y):
     return x == y
 
-def get(frame, name):
-    return frame[name]['value']
-
-def call(func, args):
-    return func, args
-
 
 
 # Token types

--- a/builtin.py
+++ b/builtin.py
@@ -5,13 +5,15 @@ class PseudoError(Exception):
     def __init__(self, msg, token, line=None):
         super().__init__(msg)
         self.token = token
+        self.line = None
+        self.col = None
         if line is not None:
             self.line = line
-        elif token:
+        elif type(token) is dict:
             self.line = token['line']
+            self.col = token['col']
         else:
             self.line = None
-        self.col = token['col'] if token else None
 
     def msg(self):
         return self.args[0]

--- a/interpreter.py
+++ b/interpreter.py
@@ -63,11 +63,11 @@ def execOutput(frame, stmt):
     print('')  # Add \n
 
 def execInput(frame, stmt):
-    name = stmt.name.accept(frame, evaluate)
+    name = stmt.name
     frame[name]['value'] = input()
 
 def execAssign(frame, stmt):
-    name = stmt.name.accept(frame, evaluate)
+    name = stmt.name
     value = stmt.expr.accept(frame, evaluate)
     frame[name]['value'] = value
 
@@ -96,7 +96,7 @@ def execRepeat(frame, stmt):
         executeStmts(frame, stmt.stmts)
 
 def execFile(frame, stmt):
-    name = stmt.name.accept(frame, evaluate)
+    name = stmt.name
     if stmt.action == 'open':
         assert stmt.mode  # Internal check
         file = {

--- a/interpreter.py
+++ b/interpreter.py
@@ -1,4 +1,3 @@
-from builtin import call
 from builtin import RuntimeError
 
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -1,4 +1,5 @@
 from builtin import RuntimeError
+from lang import Literal, Declare, Unary, Binary, Get, Call
 
 
 
@@ -15,25 +16,37 @@ def assignArgsParams(frame, args, callable):
         name = param['name'].evaluate(callable['frame'])
         callable['frame'][name]['value'] = arg.evaluate(frame)
 
+def evalLiteral(frame, literal):
+    return literal.value
+
+def evalDeclare(frame, expr):
+    pass
+
+def evalUnary(frame, expr):
+    pass
+
+def evalBinary(frame, expr):
+    pass
+
+def evalGet(frame, expr):
+    pass
+
+def evalCall(frame, expr):
+    pass
+
 def evaluate(frame, expr):
-    # Evaluating tokens
-    if 'type' in expr:
-        if expr['type'] == 'name':
-            return expr['word']
-        return expr['value']
-    # Passing frames
-    if 'oper' not in expr:
-        return expr
-    # Evaluating exprs
-    oper = expr['oper']['value']
-    if oper is call:
-        return execCall(
-            frame,
-            {'name': expr['left'], 'args': expr['right']},
-        )
-    left = evaluate(frame, expr['left'])
-    right = evaluate(frame, expr['right'])
-    return oper(left, right)
+    if isinstance(expr, Literal):
+        return expr.accept(frame, evalLiteral)
+    if isinstance(expr, Declare):
+        return expr.accept(frame, evalDeclare)
+    if isinstance(expr, Unary):
+        return expr.accept(frame, evalUnary)
+    if isinstance(expr, Binary):
+        return expr.accept(frame, evalBinary)
+    if isinstance(expr, Get):
+        return expr.accept(frame, evalGet)
+    if isinstance(expr, Call):
+        return expr.accept(frame, evalCall)
 
 def execOutput(frame, stmt):
     for expr in stmt.exprs:

--- a/interpreter.py
+++ b/interpreter.py
@@ -92,11 +92,6 @@ def execProcedure(frame, stmt):
 def execFunction(frame, stmt):
     pass
 
-def execCall(frame, stmt):
-    proc = stmt.callable.accept(frame, evaluate)
-    assignArgsParams(frame, stmt.args, proc)
-    return executeStmts(frame, proc.stmts)
-
 def execReturn(local, stmt):
     # This will typically be execute()ed within
     # evaluate() in a function call, so frame is expected

--- a/interpreter.py
+++ b/interpreter.py
@@ -86,18 +86,6 @@ def execRepeat(frame, stmt):
     while stmt.cond.accept(frame, evaluate) is False:
         executeStmts(frame, stmt.stmts)
 
-def execProcedure(frame, stmt):
-    pass
-
-def execFunction(frame, stmt):
-    pass
-
-def execReturn(local, stmt):
-    # This will typically be execute()ed within
-    # evaluate() in a function call, so frame is expected
-    # to be local
-    return stmt.expr.evaluate(local)
-
 def execFile(frame, stmt):
     name = stmt.name.accept(frame, evaluate)
     if stmt.action == 'open':
@@ -142,11 +130,11 @@ def execute(frame, stmt):
     if stmt.rule == 'repeat':
         stmt.accept(frame, execRepeat)
     if stmt.rule == 'procedure':
-        stmt.accept(frame, execProcedure)
+        pass
     if stmt.rule == 'call':
         stmt.expr.accept(frame, evalCall)
     if stmt.rule == 'function':
-        stmt.accept(frame, execFunction)
+        pass
     if stmt.rule == 'return':
         return stmt.expr.accept(frame, evaluate)
     if stmt.rule == 'file':

--- a/interpreter.py
+++ b/interpreter.py
@@ -57,9 +57,6 @@ def execInput(frame, stmt):
     name = stmt.name.accept(frame, evaluate)
     frame[name]['value'] = input()
 
-def execDeclare(frame, stmt):
-    pass
-
 def execAssign(frame, stmt):
     name = stmt.name.accept(frame, evaluate)
     value = stmt.expr.accept(frame, evaluate)
@@ -138,7 +135,7 @@ def execute(frame, stmt):
     if stmt.rule == 'input':
         stmt.accept(frame, execInput)
     if stmt.rule == 'declare':
-        stmt.accept(frame, execDeclare)
+        pass
     if stmt.rule == 'assign':
         stmt.accept(frame, execAssign)
     if stmt.rule == 'case':
@@ -152,11 +149,11 @@ def execute(frame, stmt):
     if stmt.rule == 'procedure':
         stmt.accept(frame, execProcedure)
     if stmt.rule == 'call':
-        stmt.accept(frame, execCall)
+        stmt.expr.accept(frame, evalCall)
     if stmt.rule == 'function':
         stmt.accept(frame, execFunction)
     if stmt.rule == 'return':
-        return stmt.accept(frame, execReturn)
+        return stmt.expr.accept(frame, evaluate)
     if stmt.rule == 'file':
         stmt.accept(frame, execFile)
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -1,5 +1,5 @@
 from builtin import RuntimeError
-from lang import Literal, Declare, Unary, Binary, Get, Call
+from lang import Literal, Unary, Binary, Get, Call
 
 
 
@@ -10,11 +10,6 @@ def executeStmts(frame, stmts):
         returnval = stmt.accept(frame, execute)
         if returnval:
             return returnval
-
-def assignArgsParams(frame, args, callable):
-    for arg, param in zip(args, callable['params']):
-        name = param['name'].evaluate(callable['frame'])
-        callable['frame'][name]['value'] = arg.accept(frame, evaluate)
 
 def evalLiteral(frame, literal):
     return literal.value

--- a/interpreter.py
+++ b/interpreter.py
@@ -20,16 +20,20 @@ def evalLiteral(frame, literal):
     return literal.value
 
 def evalUnary(frame, expr):
-    pass
+    rightval = expr.right.accept(frame, evaluate)
+    return expr.oper(rightval)
 
 def evalBinary(frame, expr):
-    pass
+    leftval = expr.left.accept(frame, evaluate)
+    rightval = expr.right.accept(frame, evaluate)
+    return expr.oper(leftval, rightval)
 
 def evalGet(frame, expr):
-    pass
+    return frame[expr.name]
 
 def evalCall(frame, expr):
-    pass
+    callable = expr.callable.accept(frame, evalGet)
+    # TODO: Implement evalCall
 
 def evaluate(frame, expr):
     if isinstance(expr, Literal):

--- a/interpreter.py
+++ b/interpreter.py
@@ -19,9 +19,6 @@ def assignArgsParams(frame, args, callable):
 def evalLiteral(frame, literal):
     return literal.value
 
-def evalDeclare(frame, expr):
-    pass
-
 def evalUnary(frame, expr):
     pass
 
@@ -37,8 +34,6 @@ def evalCall(frame, expr):
 def evaluate(frame, expr):
     if isinstance(expr, Literal):
         return expr.accept(frame, evalLiteral)
-    if isinstance(expr, Declare):
-        return expr.accept(frame, evalDeclare)
     if isinstance(expr, Unary):
         return expr.accept(frame, evalUnary)
     if isinstance(expr, Binary):
@@ -47,6 +42,8 @@ def evaluate(frame, expr):
         return expr.accept(frame, evalGet)
     if isinstance(expr, Call):
         return expr.accept(frame, evalCall)
+    else:
+        raise TypeError(f"Unexpected expr {expr}")
 
 def execOutput(frame, stmt):
     for expr in stmt.exprs:

--- a/interpreter.py
+++ b/interpreter.py
@@ -29,10 +29,10 @@ def evalBinary(frame, expr):
     return expr.oper(leftval, rightval)
 
 def evalGet(frame, expr):
-    return frame[expr.name]
+    return frame[expr.name]['value']
 
 def evalCall(frame, expr):
-    callable = expr.callable.accept(frame, evalGet)['value']
+    callable = expr.callable.accept(frame, evalGet)
     # Assign args to param slots
     for arg, slot in zip(expr.args, callable['params']):
         argval = arg.accept(frame, evaluate)

--- a/interpreter.py
+++ b/interpreter.py
@@ -96,7 +96,7 @@ def execRepeat(frame, stmt):
         executeStmts(frame, stmt.stmts)
 
 def execFile(frame, stmt):
-    name = stmt.name
+    name = stmt.name.accept(frame, evaluate)
     if stmt.action == 'open':
         assert stmt.mode  # Internal check
         file = {

--- a/interpreter.py
+++ b/interpreter.py
@@ -32,8 +32,16 @@ def evalGet(frame, expr):
     return frame[expr.name]
 
 def evalCall(frame, expr):
-    callable = expr.callable.accept(frame, evalGet)
-    # TODO: Implement evalCall
+    callable = expr.callable.accept(frame, evalGet)['value']
+    # Assign args to param slots
+    for arg, slot in zip(expr.args, callable['params']):
+        argval = arg.accept(frame, evaluate)
+        slot['value'] = argval
+    local = callable['frame']
+    for stmt in callable['stmts']:
+        returnval = stmt.accept(local, execute)
+        if returnval:
+            return returnval
 
 def evaluate(frame, expr):
     if isinstance(expr, Literal):

--- a/lang.py
+++ b/lang.py
@@ -182,15 +182,6 @@ class Input(Stmt):
 
 
 
-# class Declare(Stmt):
-#     __slots__ = ('rule', 'name', 'type')
-#     def __init__(self, rule, name, type):
-#         self.rule = rule
-#         self.name = name
-#         self.type = type
-
-
-
 class Assign(Stmt):
     __slots__ = ('rule', 'name', 'expr')
     def __init__(self, rule, name, expr):
@@ -229,16 +220,6 @@ class Callable(Stmt):
         self.params = params
         self.stmts = stmts
         self.returnType = returnType
-
-
-
-class Calling(Stmt):
-    # HACK: Temporary replacement for a lack of an ExprStmt
-    # Should attempt to use Call Expr
-    __slots__ = ('rule', 'callable')
-    def __init__(self, rule, callable):
-        self.rule = rule
-        self.callable = callable
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -52,6 +52,21 @@ class Name(Expr):
 
 
 
+class Declare(Expr):
+    __slots__ = ('name', 'type')
+    def __init__(self, name, type):
+        self.name = name
+        self.type = type
+
+    def resolve(self, frame):
+        frame[self.name] = {'type': self.type, 'value': None}
+        return self.type
+
+    def evaluate(self, frame):
+        return frame[self.name]
+
+
+
 class Unary(Expr):
     __slots__ = ('oper', 'right')
     def __init__(self, oper, right):

--- a/lang.py
+++ b/lang.py
@@ -145,6 +145,14 @@ class Stmt:
 
 
 
+class ExprStmt(Stmt):
+    __slots__ = ('rule', 'expr')
+    def __init__(self, rule, expr):
+        self.rule = rule
+        self.expr = expr
+
+
+
 class Output(Stmt):
     __slots__ = ('rule', 'exprs')
     def __init__(self, rule, exprs):

--- a/lang.py
+++ b/lang.py
@@ -113,13 +113,11 @@ class Get(Expr):
     def resolve(self, frame=None):
         if frame and self.frame is NULL:
             self.frame = frame
-        name = self.name.evaluate()
-        slot = self.frame[name]
+        slot = self.frame[self.name]
         return slot['type']
 
     def evaluate(self, frame):
-        name = self.name.evaluate(frame)
-        slot = self.frame[name]
+        slot = self.frame[self.name]
         return slot['value']
 
 

--- a/lang.py
+++ b/lang.py
@@ -184,12 +184,12 @@ class Input(Stmt):
 
 
 
-class Declare(Stmt):
-    __slots__ = ('rule', 'name', 'type')
-    def __init__(self, rule, name, type):
-        self.rule = rule
-        self.name = name
-        self.type = type
+# class Declare(Stmt):
+#     __slots__ = ('rule', 'name', 'type')
+#     def __init__(self, rule, name, type):
+#         self.rule = rule
+#         self.name = name
+#         self.type = type
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -6,6 +6,11 @@ from interpreter import execute
 
 
 class Expr:
+    def accept(self, frame, visitor):
+        # visitor must be a function that takes
+        # a frame and an Expr
+        return visitor(frame, self)
+
     def resolve(self, frame=None):
         raise NotImplementedError
 

--- a/parser.py
+++ b/parser.py
@@ -3,8 +3,8 @@ from builtin import ParseError
 from builtin import lte, add
 from scanner import makeToken
 from lang import Literal, Name, Unary, Binary, Get, Call
-from lang import Output, Input, Declare, Assign, Conditional, Loop
-from lang import Callable, Calling, Return, File
+from lang import ExprStmt, Output, Input, Declare, Assign
+from lang import Conditional, Loop, Callable, Calling, Return, File
 
 
 
@@ -175,21 +175,17 @@ def inputStmt(tokens):
     return Input('input', name)
 
 def declare(tokens):
-    name = identifier(tokens)
+    name = identifier(tokens).name
     expectElseError(tokens, ':', "after name")
     typetoken = consume(tokens)
     if typetoken['word'] not in TYPES:
         raise ParseError("Invalid type", typetoken)
-    var = {
-        'name': name,
-        'type': typetoken['word'],
-    }
-    return var
+    return Declare(name, typetoken['word'])
     
 def declareStmt(tokens):
-    var = declare(tokens)
+    expr = declare(tokens)
     expectElseError(tokens, '\n', "after statement")
-    return Declare('declare', var['name'], var['type'])
+    return ExprStmt('declare', expr)
 
 def assignStmt(tokens):
     name = identifier(tokens)

--- a/parser.py
+++ b/parser.py
@@ -86,7 +86,7 @@ def value(tokens):
         name = identifier(tokens)
         expr = makeExpr(
             frame=NULL,
-            name=name,
+            name=name.name,
         )
         # Function call
         args = []

--- a/parser.py
+++ b/parser.py
@@ -299,7 +299,8 @@ def procedureStmt(tokens):
 
 def callStmt(tokens):
     callable = value(tokens)
-    return Calling('call', callable)
+    expectElseError(tokens, '\n', "at end of CALL")
+    return ExprStmt('call', callable)
 
 def functionStmt(tokens):
     name = identifier(tokens)
@@ -326,7 +327,7 @@ def functionStmt(tokens):
 def returnStmt(tokens):
     expr = expression(tokens)
     expectElseError(tokens, '\n', "at end of RETURN")
-    return Return('return', expr)
+    return ExprStmt('return', expr)
 
 def openfileStmt(tokens):
     name = value(tokens)

--- a/parser.py
+++ b/parser.py
@@ -284,11 +284,11 @@ def procedureStmt(tokens):
         passby = 'BYVALUE'
         if check(tokens)['word'] in ('BYVALUE', 'BYREF'):
             passby = consume(tokens)['word']
-        var = declare(tokens)
-        params += [var]
+        expr = declare(tokens)
+        params += [expr]
         while match(tokens, ','):
-            var = declare(tokens)
-            params += [var]
+            expr = declare(tokens)
+            params += [expr]
         expectElseError(tokens, ')', "at end of parameters")
     expectElseError(tokens, '\n', "after parameters")
     stmts = []

--- a/parser.py
+++ b/parser.py
@@ -188,7 +188,7 @@ def declareStmt(tokens):
     return ExprStmt('declare', expr)
 
 def assignStmt(tokens):
-    name = identifier(tokens)
+    name = identifier(tokens).name
     expectElseError(tokens, '<-', "after name")
     expr = expression(tokens)
     expectElseError(tokens, '\n', "after statement")
@@ -252,7 +252,7 @@ def repeatStmt(tokens):
     return Loop('repeat', None, cond, stmts)
 
 def forStmt(tokens):
-    name = identifier(tokens)
+    name = identifier(tokens).name
     expectElseError(tokens, '<-', "after name")
     start = value(tokens)
     expectElseError(tokens, 'TO', "after start value")
@@ -278,7 +278,7 @@ def forStmt(tokens):
     return Loop('while', init, cond, stmts + [incr])
 
 def procedureStmt(tokens):
-    name = identifier(tokens)
+    name = identifier(tokens).name
     params = []
     if match(tokens, '('):
         passby = 'BYVALUE'
@@ -303,7 +303,7 @@ def callStmt(tokens):
     return ExprStmt('call', callable)
 
 def functionStmt(tokens):
-    name = identifier(tokens)
+    name = identifier(tokens).name
     params = []
     if match(tokens, '('):
         passby = 'BYVALUE'
@@ -341,7 +341,7 @@ def openfileStmt(tokens):
 def readfileStmt(tokens):
     name = value(tokens)
     expectElseError(tokens, ',', "after file identifier")
-    data = identifier(tokens)
+    data = identifier(tokens).name
     expectElseError(tokens, '\n')
     return File('file', 'read', name, None, data)
 

--- a/parser.py
+++ b/parser.py
@@ -4,7 +4,7 @@ from builtin import lte, add
 from scanner import makeToken
 from lang import Literal, Name, Unary, Binary, Get, Call
 from lang import ExprStmt, Output, Input, Declare, Assign
-from lang import Conditional, Loop, Callable, Calling, Return, File
+from lang import Conditional, Loop, Callable, Return, File
 
 
 

--- a/resolver.py
+++ b/resolver.py
@@ -197,7 +197,7 @@ def verifyReturn(local, stmt):
     return stmt.expr.resolve(local)
 
 def verifyFile(frame, stmt):
-    name = stmt.name
+    name = stmt.name.accept(frame, value)
     if stmt.action == 'open':
         if name in frame:
             raise LogicError("File already opened", stmt.name)

--- a/resolver.py
+++ b/resolver.py
@@ -1,4 +1,3 @@
-from builtin import get, call
 from builtin import lt, lte, gt, gte, ne, eq
 from builtin import add, sub, mul, div
 from builtin import LogicError

--- a/resolver.py
+++ b/resolver.py
@@ -148,14 +148,19 @@ def verifyLoop(frame, stmt):
 def verifyProcedure(frame, stmt):
     # Set up local frame
     local = {}
-    for expr in stmt.params:
+    for i, expr in enumerate(stmt.params):
         if stmt.passby == 'BYREF':
             exprtype = expr.accept(local, resolveDeclare)
             expectTypeElseError(exprtype, frame[expr.name]['type'])
             # Reference frame vars in local
             local[expr.name] = frame[expr.name]
         else:
-            local[expr.name] = {'type': expr.type, 'value': None}
+            local[expr.name] = {
+                'type': expr.type,
+                'value': None,
+            }
+        # params: replace Declare Expr with slot
+        stmt.params[i] = local[expr.name]
     # Resolve procedure statements using local
     verifyStmts(local, stmt.stmts)
     # Declare procedure in frame

--- a/resolver.py
+++ b/resolver.py
@@ -43,9 +43,14 @@ def verifyInput(frame, stmt):
             stmt.name,
         )
 
+def resolveDeclare(frame, expr):
+    if expr.name in frame:
+        raise LogicError("Already declared", expr.name)
+    frame[expr.name] = {'type': expr.type, 'value': None}
+    return expr.type
+
 def verifyDeclare(frame, stmt):
-    name = stmt.name.resolve(frame)
-    frame[name] = {'type': stmt.type, 'value': None}
+    stmt.expr.accept(resolveDeclare)
 
 def verifyAssign(frame, stmt):
     name = stmt.name.resolve(frame)

--- a/resolver.py
+++ b/resolver.py
@@ -13,7 +13,7 @@ def expectTypeElseError(exprtype, expected):
 
 def resolveExprs(frame, exprs):
     for expr in exprs:
-        expr.resolve(frame)
+        expr.accept(frame, resolve)
 
 def verifyStmts(frame, stmts):
     for stmt in stmts:
@@ -117,13 +117,13 @@ def verifyAssign(frame, stmt):
     expectTypeElseError(exprtype, frame[stmt.name]['type'])
 
 def verifyCase(frame, stmt):
-    stmt.cond.resolve(frame)
+    stmt.cond.accept(frame, resolve)
     verifyStmts(frame, stmt.stmts.values())
     if stmt.fallback:
         stmt.fallback.accept(frame, verify)
 
 def verifyIf(frame, stmt):
-    stmt.cond.resolve(frame)
+    stmt.cond.accept(frame, resolve)
     expectTypeElseError(stmt.cond, 'BOOLEAN')
     verifyStmts(frame, stmt.stmts[True])
     if stmt.fallback:
@@ -212,7 +212,7 @@ def verifyFile(frame, stmt):
         if file['type'] != 'READ':
             raise LogicError("File mode is {file['type']}", stmt.name)
     elif stmt.action == 'write':
-        stmt.data.resolve(frame)
+        stmt.data.accept(frame, resolve)
         if name not in frame:
             raise LogicError("File not open", stmt.name)
         file = frame[name]

--- a/resolver.py
+++ b/resolver.py
@@ -143,8 +143,8 @@ def verifyIf(frame, stmt):
 def verifyLoop(frame, stmt):
     if stmt.init:
         stmt.init.accept(frame, verify)
-    stmt.cond.resolve(frame)
-    expectTypeElseError(frame, stmt.cond, 'BOOLEAN')
+    condtype = stmt.cond.accept(frame, resolve)
+    expectTypeElseError(condtype, 'BOOLEAN')
     verifyStmts(frame, stmt.stmts)
 
 def verifyProcedure(frame, stmt):
@@ -152,7 +152,8 @@ def verifyProcedure(frame, stmt):
     local = {}
     for expr in stmt.params:
         if stmt.passby == 'BYREF':
-            expectTypeElseError(frame, expr.type, frame[expr.name]['type'])
+            exprtype = expr.accept(local, resolveDeclare)
+            expectTypeElseError(exprtype, frame[expr.name]['type'])
             # Reference frame vars in local
             local[expr.name] = frame[expr.name]
         else:

--- a/resolver.py
+++ b/resolver.py
@@ -166,31 +166,6 @@ def verifyProcedure(frame, stmt):
         }
     }
 
-def verifyCall(frame, stmt):
-    stmt.callable.resolve(frame)
-    proc = stmt.callable.callable.evaluate(frame)
-    expectTypeElseError(frame, stmt.callable, 'procedure')
-    # if len(stmt.args) != len(proc['params']):
-    #     raise LogicError(
-    #         f"Expected {len(proc['params'])} args, got {len(stmt.args)}",
-    #         None,
-    #     )
-    # # Type-check arguments
-    # local = proc['frame']
-    # for arg, param in zip(stmt.args, proc['params']):
-    #     if stmt.passby == 'BYREF':
-    #         arg.resolve(frame)
-    #         # Only names allowed for BYREF arguments
-    #         if not isinstance(arg, Get):
-    #             raise LogicError(
-    #                 'BYREF arg must be a name, not expression',
-    #                 None,
-    #             )
-    #     else:
-    #         arg.resolve(local)
-    #     paramtype = param['type']
-    #     expectTypeElseError(frame, arg, paramtype)
-
 def verifyFunction(frame, stmt):
     # Set up local frame
     local = {}

--- a/resolver.py
+++ b/resolver.py
@@ -30,11 +30,33 @@ def verifyInput(frame, stmt):
             stmt.name,
         )
 
+def get(frame, expr):
+    """Evaluate a Get expr to retrieve value from frame"""
+    if expr.name not in frame:
+        raise LogicError("Undeclared", expr.name)
+    if frame[expr.name] is None:
+        raise LogicError("No value assigned", expr.name)
+    return frame[expr.name]
+
+def value(frame, expr):
+    """Return the value of a Literal"""
+    return expr.value
+
+def resolveLiteral(frame, literal):
+    return literal.type
+
 def resolveDeclare(frame, expr):
     if expr.name in frame:
         raise LogicError("Already declared", expr.name)
     frame[expr.name] = {'type': expr.type, 'value': None}
     return expr.type
+
+def resolveUnary(frame, expr):
+    expr.right.accept(frame, resolve)
+
+def resolveBinary(frame, expr):
+    expr.left.accept(frame, resolve)
+    expr.right.accept(frame, resolve)
 
 def resolveGet(frame, expr):
     """Insert frame into Get expr"""

--- a/resolver.py
+++ b/resolver.py
@@ -35,7 +35,7 @@ def verifyOutput(frame, stmt):
     resolveExprs(frame, stmt.exprs)
 
 def verifyInput(frame, stmt):
-    name = stmt.name.resolve(frame)
+    name = stmt.name
     if name not in frame:
         raise LogicError(
             f'Name not declared',
@@ -63,13 +63,36 @@ def get(frame, expr):
 
 def resolveCall(frame, expr):
     # Insert frame
+    breakpoint()
     calltype = expr.callable.accept(frame, resolveGet)
     callable = expr.callable.accept(frame, get)
+    breakpoint()
+    expectTypeElseError(frame, expr.callable, 'procedure')
+    # if len(stmt.args) != len(proc['params']):
+    #     raise LogicError(
+    #         f"Expected {len(proc['params'])} args, got {len(stmt.args)}",
+    #         None,
+    #     )
+    # # Type-check arguments
+    # local = proc['frame']
+    # for arg, param in zip(stmt.args, proc['params']):
+    #     if stmt.passby == 'BYREF':
+    #         arg.resolve(frame)
+    #         # Only names allowed for BYREF arguments
+    #         if not isinstance(arg, Get):
+    #             raise LogicError(
+    #                 'BYREF arg must be a name, not expression',
+    #                 None,
+    #             )
+    #     else:
+    #         arg.resolve(local)
+    #     paramtype = param['type']
+    #     expectTypeElseError(frame, arg, paramtype)
 
 
 
 def verifyAssign(frame, stmt):
-    name = stmt.name.resolve(frame)
+    name = stmt.name
     expectTypeElseError(frame, stmt.expr, frame[name]['type'])
 
 def verifyCase(frame, stmt):
@@ -105,7 +128,7 @@ def verifyProcedure(frame, stmt):
     # Resolve procedure statements using local
     verifyStmts(local, stmt.stmts)
     # Declare procedure in frame
-    name = stmt.name.resolve(frame)
+    name = stmt.name
     frame[name] = {
         'type': 'procedure',
         'value': {
@@ -147,7 +170,7 @@ def verifyFunction(frame, stmt):
     for expr in stmt.params:
         # Declare vars in local
         expr.accept(local, resolveDeclare)
-    name = stmt.name.resolve(frame)
+    name = stmt.name
     returnType = stmt.returnType
     # Resolve procedure statements using local
     hasReturn = False
@@ -180,7 +203,7 @@ def verifyReturn(local, stmt):
     return stmt.expr.resolve(local)
 
 def verifyFile(frame, stmt):
-    name = stmt.name.resolve(frame)
+    name = stmt.name
     if stmt.action == 'open':
         if name in frame:
             raise LogicError("File already opened", stmt.name)

--- a/resolver.py
+++ b/resolver.py
@@ -49,9 +49,6 @@ def resolveDeclare(frame, expr):
     frame[expr.name] = {'type': expr.type, 'value': None}
     return expr.type
 
-def verifyDeclare(frame, stmt):
-    stmt.expr.accept(resolveDeclare)
-
 def verifyAssign(frame, stmt):
     name = stmt.name.resolve(frame)
     expectTypeElseError(frame, stmt.expr, frame[name]['type'])
@@ -130,9 +127,9 @@ def verifyCall(frame, stmt):
 def verifyFunction(frame, stmt):
     # Set up local frame
     local = {}
-    for var in stmt.params:
+    for expr in stmt.params:
         # Declare vars in local
-        verifyDeclare(local, var)
+        expr.accept(local, resolveDeclare)
     name = stmt.name.resolve(frame)
     returnType = stmt.returnType
     # Resolve procedure statements using local
@@ -196,7 +193,7 @@ def verify(frame, stmt):
     if stmt.rule == 'input':
         stmt.accept(frame, verifyInput)
     elif stmt.rule == 'declare':
-        stmt.accept(frame, verifyDeclare)
+        stmt.expr.accept(resolveDeclare)
     elif stmt.rule == 'assign':
         stmt.accept(frame, verifyAssign)
     elif stmt.rule == 'case':

--- a/resolver.py
+++ b/resolver.py
@@ -1,27 +1,15 @@
 from builtin import lt, lte, gt, gte, ne, eq
 from builtin import add, sub, mul, div
 from builtin import LogicError
-from lang import Get
+from lang import Literal, Declare, Unary, Binary, Get, Call
 
 
 
 # Helper functions
 
-def expectTypeElseError(frame, expr, expected):
-    exprtype = expr.resolve(frame)
-    if expected != exprtype:
-        token = None
-        # if type(expr) is dict:
-        #     if 'line' in expr:
-        #         token = expr
-        #     elif 'line' in expr['left']:
-        #         token = expr['left']
-        #     elif 'line' in expr['right']:
-        #         token = expr['right']
-        raise LogicError(
-            f"Expected {repr(expected)}, got {repr(exprtype)}",
-            token,
-        )
+def expectTypeElseError(exprtype, expected):
+    if exprtype != expected:
+        raise LogicError(f"Expected {expected}", exprtype)
 
 def resolveExprs(frame, exprs):
     for expr in exprs:

--- a/resolver.py
+++ b/resolver.py
@@ -198,12 +198,6 @@ def verifyFunction(frame, stmt):
         }
     }
 
-def verifyReturn(local, stmt):
-    # This will typically be verify()ed within
-    # verifyFunction(), so frame is expected to
-    # be local
-    return stmt.expr.resolve(local)
-
 def verifyFile(frame, stmt):
     name = stmt.name.accept(frame, value)
     if stmt.action == 'open':

--- a/resolver.py
+++ b/resolver.py
@@ -81,10 +81,8 @@ def resolveGet(frame, expr):
 
 def resolveCall(frame, expr):
     # Insert frame
-    breakpoint()
     calltype = expr.callable.accept(frame, resolveGet)
     callable = expr.callable.accept(frame, get)
-    breakpoint()
     expectTypeElseError(calltype, 'procedure')
     # if len(stmt.args) != len(proc['params']):
     #     raise LogicError(

--- a/resolver.py
+++ b/resolver.py
@@ -46,17 +46,32 @@ def resolveLiteral(frame, literal):
     return literal.type
 
 def resolveDeclare(frame, expr):
+    """Declare variable in frame"""
     if expr.name in frame:
         raise LogicError("Already declared", expr.name)
     frame[expr.name] = {'type': expr.type, 'value': None}
     return expr.type
 
 def resolveUnary(frame, expr):
-    expr.right.accept(frame, resolve)
+    righttype = expr.right.accept(frame, resolve)
+    if expr.oper is sub:
+        expectTypeElseError(righttype, 'INTEGER')
+        return 'INTEGER'
+    else:
+        raise ValueError("Unexpected oper {expr.oper}")
 
 def resolveBinary(frame, expr):
-    expr.left.accept(frame, resolve)
-    expr.right.accept(frame, resolve)
+    lefttype = expr.left.accept(frame, resolve)
+    righttype = expr.right.accept(frame, resolve)
+    if expr.oper in (gt, gte, lt, lte, ne, eq):
+        expectTypeElseError(lefttype, 'INTEGER')
+        expectTypeElseError(righttype, 'INTEGER')
+        return 'BOOLEAN'
+    if expr.oper in (add, sub, mul, div):
+        # TODO: Handle REAL type
+        expectTypeElseError(lefttype, 'INTEGER')
+        expectTypeElseError(righttype, 'INTEGER')
+        return 'INTEGER'
 
 def resolveGet(frame, expr):
     """Insert frame into Get expr"""

--- a/resolver.py
+++ b/resolver.py
@@ -62,6 +62,7 @@ def resolveGet(frame, expr):
     """Insert frame into Get expr"""
     assert isinstance(expr, Get), "Not a Get Expr"
     expr.frame = frame
+    return frame[expr.name]['type']
 
 def resolveCall(frame, expr):
     # Insert frame
@@ -95,21 +96,21 @@ def resolveCall(frame, expr):
 
 def resolve(frame, expr):
     if isinstance(expr, Literal):
-        expr.accept(frame, resolveLiteral)
+        return expr.accept(frame, resolveLiteral)
     if isinstance(expr, Declare):
-        expr.accept(frame, resolveDeclare)
+        return expr.accept(frame, resolveDeclare)
     elif isinstance(expr, Unary):
-        expr.accept(frame, resolveUnary)
+        return expr.accept(frame, resolveUnary)
     elif isinstance(expr, Binary):
-        expr.accept(frame, resolveBinary)
+        return expr.accept(frame, resolveBinary)
     elif isinstance(expr, Get):
-        expr.accept(frame, resolveGet)
+        return expr.accept(frame, resolveGet)
     elif isinstance(expr, Call):
-        expr.accept(frame, resolveCall)
+        return expr.accept(frame, resolveCall)
         
 def verifyAssign(frame, stmt):
-    name = stmt.name
-    expectTypeElseError(stmt.expr, frame[name]['type'])
+    exprtype = stmt.expr.accept(frame, resolve)
+    expectTypeElseError(exprtype, frame[stmt.name]['type'])
 
 def verifyCase(frame, stmt):
     stmt.cond.resolve(frame)

--- a/resolver.py
+++ b/resolver.py
@@ -50,30 +50,9 @@ def resolveDeclare(frame, expr):
     return expr.type
 
 def resolveCall(frame, expr):
-    breakpoint()
-    expr.callable.resolve(frame)
-    proc = expr.callable.callable.evaluate(frame)
-    expectTypeElseError(frame, expr.callable, 'procedure')
-    # if len(stmt.args) != len(proc['params']):
-    #     raise LogicError(
-    #         f"Expected {len(proc['params'])} args, got {len(stmt.args)}",
-    #         None,
-    #     )
-    # # Type-check arguments
-    # local = proc['frame']
-    # for arg, param in zip(stmt.args, proc['params']):
-    #     if stmt.passby == 'BYREF':
-    #         arg.resolve(frame)
-    #         # Only names allowed for BYREF arguments
-    #         if not isinstance(arg, Get):
-    #             raise LogicError(
-    #                 'BYREF arg must be a name, not expression',
-    #                 None,
-    #             )
-    #     else:
-    #         arg.resolve(local)
-    #     paramtype = param['type']
-    #     expectTypeElseError(frame, arg, paramtype)
+    # Insert frame
+    calltype = expr.callable.accept(frame, resolveGet)
+    callable = expr.callable.accept(frame, get)
 
 
 
@@ -219,7 +198,7 @@ def verify(frame, stmt):
     if stmt.rule == 'input':
         stmt.accept(frame, verifyInput)
     elif stmt.rule == 'declare':
-        stmt.expr.accept(resolveDeclare)
+        stmt.expr.accept(frame, resolveDeclare)
     elif stmt.rule == 'assign':
         stmt.accept(frame, verifyAssign)
     elif stmt.rule == 'case':

--- a/resolver.py
+++ b/resolver.py
@@ -48,6 +48,12 @@ def resolveDeclare(frame, expr):
     frame[expr.name] = {'type': expr.type, 'value': None}
     return expr.type
 
+def resolveGet(frame, expr):
+    expr.frame = frame
+
+def get(frame, expr):
+    return frame[expr.name]
+
 def resolveCall(frame, expr):
     # Insert frame
     calltype = expr.callable.accept(frame, resolveGet)

--- a/resolver.py
+++ b/resolver.py
@@ -253,7 +253,7 @@ def verify(frame, stmt):
     elif stmt.rule == 'file':
         stmt.accept(frame, verifyFile)
     elif stmt.rule == 'return':
-        return stmt.accept(frame, verifyReturn)
+        return stmt.expr.accept(frame, resolve)
 
 def inspect(statements):
     frame = {}

--- a/resolver.py
+++ b/resolver.py
@@ -50,10 +50,15 @@ def resolveDeclare(frame, expr):
 
 def resolveGet(frame, expr):
     """Insert frame into Get expr"""
+    assert isinstance(expr, Get), "Not a Get Expr"
     expr.frame = frame
 
 def get(frame, expr):
     """Evaluate a Get expr to retrieve value from frame"""
+    if expr.name not in frame:
+        raise LogicError("Undeclared", expr.name)
+    if frame[expr.name] is None:
+        raise LogicError("No value assigned", expr.name)
     return frame[expr.name]
 
 def resolveCall(frame, expr):

--- a/resolver.py
+++ b/resolver.py
@@ -82,28 +82,19 @@ def resolveGet(frame, expr):
 def resolveCall(frame, expr):
     # Insert frame
     calltype = expr.callable.accept(frame, resolveGet)
-    callable = expr.callable.accept(frame, get)
+    callable = expr.callable.accept(frame, get)['value']
     expectTypeElseError(calltype, 'procedure')
-    # if len(stmt.args) != len(proc['params']):
-    #     raise LogicError(
-    #         f"Expected {len(proc['params'])} args, got {len(stmt.args)}",
-    #         None,
-    #     )
-    # # Type-check arguments
-    # local = proc['frame']
-    # for arg, param in zip(stmt.args, proc['params']):
-    #     if stmt.passby == 'BYREF':
-    #         arg.resolve(frame)
-    #         # Only names allowed for BYREF arguments
-    #         if not isinstance(arg, Get):
-    #             raise LogicError(
-    #                 'BYREF arg must be a name, not expression',
-    #                 None,
-    #             )
-    #     else:
-    #         arg.resolve(local)
-    #     paramtype = param['type']
-    #     expectTypeElseError(frame, arg, paramtype)
+    numArgs, numParams = len(expr.args), len(callable['params'])
+    if numArgs != numParams:
+        raise LogicError(
+            f"Expected {numParams} args, got {numArgs}",
+            None,
+        )
+    # Type-check arguments
+    for arg, param in zip(expr.args, callable['params']):
+        # param is a slot from either local or frame
+        argtype = arg.accept(frame, resolve)
+        expectTypeElseError(argtype, param['type'])
 
 
 

--- a/resolver.py
+++ b/resolver.py
@@ -49,9 +49,11 @@ def resolveDeclare(frame, expr):
     return expr.type
 
 def resolveGet(frame, expr):
+    """Insert frame into Get expr"""
     expr.frame = frame
 
 def get(frame, expr):
+    """Evaluate a Get expr to retrieve value from frame"""
     return frame[expr.name]
 
 def resolveCall(frame, expr):

--- a/resolver.py
+++ b/resolver.py
@@ -125,7 +125,7 @@ def verifyIf(frame, stmt):
     if stmt.fallback:
         verifyStmts(frame, stmt.fallback)
 
-def verifyWhile(frame, stmt):
+def verifyLoop(frame, stmt):
     if stmt.init:
         stmt.init.accept(frame, verify)
     stmt.cond.resolve(frame)
@@ -258,7 +258,7 @@ def verify(frame, stmt):
     elif stmt.rule == 'if':
         stmt.accept(frame, verifyIf)
     elif stmt.rule in ('while', 'repeat', 'for'):
-        stmt.accept(frame, verifyWhile)
+        stmt.accept(frame, verifyLoop)
     elif stmt.rule == 'procedure':
         stmt.accept(frame, verifyProcedure)
     elif stmt.rule == 'call':


### PR DESCRIPTION
# Introducing Expression Statements

There are some pseudocode features that straddle the line between expressions and features. For instance:

`DECLARE Number : INTEGER`

and

`PROCEDURE(Number : INTEGER)`

In both cases, `Number : INTEGER` declares a variable `Number` of type `INTEGER`. DECLARE means this variable is in the global space, while PROCEDURE() means the variable is in the procedure's local space.

So `Number : INTEGER` is an expression, but has to be executed like a statement (since it has effects, namely declaration of a variable).

Then there's the story of CALL, which essentially does the same thing as a function call but for a procedure.

Let's make a new kind of statement for these, so we can `verify()` and `execute()` them. We'll call them ... `ExprStmt`s.