### PR TITLE
16g OOP: Error reporting

### DIFF
--- a/interpreter.py
+++ b/interpreter.py
@@ -1,6 +1,6 @@
 from builtin import RuntimeError
 from lang import Frame, File
-from lang import Literal, Unary, Binary, Get, Call
+from lang import Literal, Unary, Binary, Get, Call, Assign
 
 
 
@@ -51,6 +51,10 @@ def evalCall(frame, expr):
         if returnval:
             return returnval
 
+def evalAssign(frame, expr):
+    value = expr.expr.accept(frame, evaluate)
+    frame.setValue(expr.name, value)
+
 def evaluate(frame, expr):
     if isinstance(expr, Literal):
         return expr.accept(frame, evalLiteral)
@@ -58,6 +62,8 @@ def evaluate(frame, expr):
         return expr.accept(frame, evalUnary)
     if isinstance(expr, Binary):
         return expr.accept(frame, evalBinary)
+    if isinstance(expr, Assign):
+        return expr.accept(frame, evalAssign)
     if isinstance(expr, Get):
         return expr.accept(frame, evalGet)
     if isinstance(expr, Call):
@@ -81,10 +87,6 @@ def execOutput(frame, stmt):
 def execInput(frame, stmt):
     name = stmt.name
     frame.setValue(name, input())
-
-def execAssign(frame, stmt):
-    value = stmt.expr.accept(frame, evaluate)
-    frame.setValue(stmt.name, value)
 
 def execCase(frame, stmt):
     cond = stmt.cond.accept(frame, evaluate)
@@ -152,7 +154,7 @@ def execute(frame, stmt):
     if stmt.rule == 'input':
         stmt.accept(frame, execInput)
     if stmt.rule == 'assign':
-        stmt.accept(frame, execAssign)
+        stmt.expr.accept(frame, evaluate)
     if stmt.rule == 'case':
         stmt.accept(frame, execCase)
     if stmt.rule == 'if':

--- a/interpreter.py
+++ b/interpreter.py
@@ -6,20 +6,20 @@ from lang import Literal, Unary, Binary, Get, Call, Assign
 
 # Helper functions
 
-def expectTypeElseError(exprmode, expected, errmsg="Expected", name=None):
+def expectTypeElseError(exprmode, expected, errmsg="Expected", token=None):
     if type(expected) is str:
         expected = (expected,)
     if not exprmode in expected:
-        if not name: name = exprmode
-        raise RuntimeError(f"{errmsg} {expected}", name)
+        if not token: token = exprmode
+        raise RuntimeError(f"{errmsg} {expected}", token)
 
-def declaredElseError(frame, name, errmsg="Undeclared", declaredType=None):
+def declaredElseError(frame, name, errmsg="Undeclared", token=None):
     if not frame.has(name):
-        raise RuntimeError(errmsg, name)
+        raise RuntimeError(errmsg, token)
 
-def undeclaredElseError(frame, name, errmsg="Already declared", declaredType=None):
+def undeclaredElseError(frame, name, errmsg="Already declared", token=None):
     if frame.has(name):
-        raise RuntimeError(errmsg, name)
+        raise RuntimeError(errmsg, token)
 
 # Evaluators
 
@@ -115,26 +115,26 @@ def execRepeat(frame, stmt):
 def execFile(frame, stmt):
     name = stmt.name.accept(frame, evalLiteral)
     if stmt.action == 'open':
-        undeclaredElseError(frame, name, "File already opened")
+        undeclaredElseError(frame, name, "File already opened", stmt.name.token())
         frame.declare(name, 'FILE')
         file = File(name, stmt.mode, open(name, stmt.mode[0].lower()))
         frame.setValue(name, file)
     elif stmt.action == 'read':
-        declaredElseError(frame, name, "File not open")
+        declaredElseError(frame, name, "File not open", stmt.name.token())
         file = frame.getValue(name)
-        expectTypeElseError(frame.getType(name), 'FILE')
-        expectTypeElseError(file.mode, 'READ')
+        expectTypeElseError(frame.getType(name), 'FILE', stmt.name.token())
+        expectTypeElseError(file.mode, 'READ', stmt.name.token())
         varname = stmt.data.accept(frame, evaluate)
-        declaredElseError(frame, varname)
+        declaredElseError(frame, varname, stmt.data.token())
         # TODO: Catch and handle Python file io errors
         line = file.iohandler.readline().rstrip()
         # TODO: Type conversion
         frame.setValue(varname, line)
     elif stmt.action == 'write':
-        declaredElseError(frame, name, "File not open")
+        declaredElseError(frame, name, "File not open", stmt.name.token())
         file = frame.getValue(name)
-        expectTypeElseError(frame.getType(name), 'FILE')
-        expectTypeElseError(file.mode, ('WRITE', 'APPEND'))
+        expectTypeElseError(frame.getType(name), 'FILE', stmt.name.token())
+        expectTypeElseError(file.mode, ('WRITE', 'APPEND'), stmt.name.token())
         writedata = str(stmt.data.accept(frame, evaluate))
         # Move pointer to next line after writing
         if not writedata.endswith('\n'):
@@ -142,9 +142,9 @@ def execFile(frame, stmt):
         # TODO: Catch and handle Python file io errors
         file.iohandler.write(writedata)
     elif stmt.action == 'close':
-        declaredElseError(frame, name, "File not open")
+        declaredElseError(frame, name, "File not open", stmt.name.token())
         file = frame.getValue(name)
-        expectTypeElseError(frame.getType(name), 'FILE')
+        expectTypeElseError(frame.getType(name), 'FILE', stmt.name.token())
         file.iohandler.close()
         frame.delete(name)
 

--- a/lang.py
+++ b/lang.py
@@ -74,7 +74,8 @@ class TypedValue:
     Each TypedValue has a type and a value.
     """
     __slots__ = ('type', 'value')
-    def __init__(self, type, value):
+    def __init__(self, type, value, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.type = type
         self.value = value
 

--- a/lang.py
+++ b/lang.py
@@ -205,6 +205,15 @@ class Declare(Expr):
 
 
 
+class Assign(Expr):
+    __slots__ = ('name', 'expr')
+    def __init__(self, name, expr, token=None):
+        super().__init__(token=token)
+        self.name = name
+        self.expr = expr
+
+
+
 class Unary(Expr):
     __slots__ = ('oper', 'right')
     def __init__(self, oper, right, token=None):

--- a/lang.py
+++ b/lang.py
@@ -151,12 +151,21 @@ class Expr:
 
     Methods
     -------
+    - token() -> dict
+        Returns the token asociated with the expr, for error
+        reporting purposes.
     - accept(frame, visitor) -> Any
         Enables a visitor to carry out operations on the
         Expr (with a provided frame).
         The visitor should take in two arguments: a frame,
         and an Expr.
     """
+    def __init__(self, token=None):
+        self.token = token
+
+    def token(self):
+        return self.token
+
     def accept(self, frame, visitor):
         # visitor must be a function that takes
         # a frame and an Expr

--- a/lang.py
+++ b/lang.py
@@ -190,14 +190,16 @@ class Literal(TypedValue, Expr):
 
 class Name(Expr):
     __slots__ = ('name',)
-    def __init__(self, name):
+    def __init__(self, name, token=None):
+        super().__init__(token=token)
         self.name = name
 
 
 
 class Declare(Expr):
     __slots__ = ('name', 'type')
-    def __init__(self, name, type):
+    def __init__(self, name, type, token=None):
+        super().__init__(token=token)
         self.name = name
         self.type = type
 
@@ -205,7 +207,8 @@ class Declare(Expr):
 
 class Unary(Expr):
     __slots__ = ('oper', 'right')
-    def __init__(self, oper, right):
+    def __init__(self, oper, right, token=None):
+        super().__init__(token=token)
         self.oper = oper
         self.right = right
 
@@ -213,7 +216,8 @@ class Unary(Expr):
 
 class Binary(Expr):
     __slots__ = ('left', 'oper', 'right')
-    def __init__(self, left, oper, right):
+    def __init__(self, left, oper, right, token=None):
+        super().__init__(token=token)
         self.left = left
         self.oper = oper
         self.right = right
@@ -222,7 +226,8 @@ class Binary(Expr):
 
 class Get(Expr):
     __slots__ = ('frame', 'name')
-    def __init__(self, frame, name):
+    def __init__(self, frame, name, token=None):
+        super().__init__(token=token)
         self.frame = frame
         self.name = name
 
@@ -230,7 +235,8 @@ class Get(Expr):
 
 class Call(Expr):
     __slots__ = ('callable', 'args')
-    def __init__(self, callable, args):
+    def __init__(self, callable, args, token=None):
+        super().__init__(token=token)
         self.callable = callable
         self.args = args
 

--- a/lang.py
+++ b/lang.py
@@ -289,12 +289,12 @@ class Input(Stmt):
 
 
 
-class Assign(Stmt):
-    __slots__ = ('rule', 'name', 'expr')
-    def __init__(self, rule, name, expr):
-        self.rule = rule
-        self.name = name
-        self.expr = expr
+# class Assign(Stmt):
+#     __slots__ = ('rule', 'name', 'expr')
+#     def __init__(self, rule, name, expr):
+#         self.rule = rule
+#         self.name = name
+#         self.expr = expr
 
 
 

--- a/lang.py
+++ b/lang.py
@@ -162,10 +162,10 @@ class Expr:
         and an Expr.
     """
     def __init__(self, token=None):
-        self.token = token
+        self._token = token
 
     def token(self):
-        return self.token
+        return self._token
 
     def accept(self, frame, visitor):
         # visitor must be a function that takes

--- a/parser.py
+++ b/parser.py
@@ -72,6 +72,15 @@ def identifier(tokens):
 
 def value(tokens):
     token = check(tokens)
+    # Unary expressions
+    if token['word'] in ('-',):
+        oper = consume(tokens)
+        right = expression(tokens)
+        return makeExpr(
+            oper=oper['value'],
+            right=right,
+            token=oper,
+        )
     # A single value
     if token['type'] in ['INTEGER', 'STRING']:
         expr = makeExpr(

--- a/parser.py
+++ b/parser.py
@@ -301,9 +301,14 @@ def forStmt(tokens):
     getCounter = makeExpr(frame=NULL, name=init.name, token=init.token())
     cond = Binary(getCounter, lte, end, token=init.token())
     # Add increment statement
-    incr = Binary(getCounter, add, step, token=step.token())
-    update = Assign(name=init.name, expr=incr, token=init.token())
-    return Loop('while', init, cond, stmts + [update])
+    incr = Assign(
+        name=init.name,
+        expr=Binary(getCounter, add, step, token=step.token()),
+        token=init.token(),
+    )
+    initStmt = ExprStmt('assign', init)
+    incrStmt = ExprStmt('assign', incr)
+    return Loop('while', initStmt, cond, stmts + [incrStmt])
 
 def procedureStmt(tokens):
     name = identifier(tokens).name

--- a/parser.py
+++ b/parser.py
@@ -25,7 +25,7 @@ def consume(tokens):
 def makeExpr(
     *,
     type=None, value=None,
-    frame=None, name=None,
+    frame=None, name=None, expr=None,
     left=None, oper=None, right=None,
     callable=None, args=None,
     token=None,
@@ -33,6 +33,8 @@ def makeExpr(
     if name is not None:
         if frame is not None:
             return Get(frame, name, token=token)
+        elif expr is not None:
+            return Assign(name, expr, token=token)
         else:
             return Name(name, token=token)
     if type is not None and value is not None:
@@ -167,6 +169,8 @@ def equality(tokens):
 def expression(tokens):
     expr = equality(tokens)
     return expr
+
+def assignment(tokens):
 
 # Statement parsers
 

--- a/parser.py
+++ b/parser.py
@@ -52,7 +52,8 @@ def expectElseError(tokens, word, addmsg=None):
     if check(tokens)['word'] == word:
         consume(tokens)
         return True
-    msg = f"Expected {addmsg}" if addmsg else "Expected"
+    msg = f"Expected {word}"
+    if addmsg: msg += f" {addmsg}"
     raise ParseError(msg, check(tokens))
 
 def match(tokens, *words):

--- a/parser.py
+++ b/parser.py
@@ -171,6 +171,10 @@ def expression(tokens):
     return expr
 
 def assignment(tokens):
+    name = identifier(tokens)
+    expectElseError(tokens, '<-', "after name")
+    expr = expression(tokens)
+    return makeExpr(name=name.name, expr=expr, token=name)
 
 # Statement parsers
 

--- a/parser.py
+++ b/parser.py
@@ -70,6 +70,14 @@ def identifier(tokens):
     else:
         raise ParseError(f"Expected variable name", token)
 
+def literal(tokens):
+    token = consume(tokens)
+    return makeExpr(
+        type=token['type'],
+        value=token['value'],
+        token=token,
+    )
+
 def value(tokens):
     token = check(tokens)
     # Unary expressions
@@ -82,14 +90,8 @@ def value(tokens):
             token=oper,
         )
     # A single value
-    if token['type'] in ['INTEGER', 'STRING']:
-        expr = makeExpr(
-            type=token['type'],
-            value=token['value'],
-            token=token,
-        )
-        consume(tokens)
-        return expr
+    if check(tokens)['type'] in ['INTEGER', 'STRING']:
+        return literal(tokens)
     #  A grouping
     elif match(tokens, '('):
         expr = expression(tokens)

--- a/parser.py
+++ b/parser.py
@@ -85,7 +85,7 @@ def value(tokens):
     elif match(tokens, '('):
         expr = expression(tokens)
         expectElseError(tokens, ')', "after '('")
-        return expr        
+        return expr
     elif token['type'] == 'name':
         name = identifier(tokens)
         expr = makeExpr(
@@ -121,7 +121,7 @@ def muldiv(tokens):
             left=expr,
             oper=oper['value'],
             right=right,
-            token=token,
+            token=oper,
         )
     return expr
 
@@ -134,7 +134,7 @@ def addsub(tokens):
             left=expr,
             oper=oper['value'],
             right=right,
-            token=token,
+            token=oper,
         )
     return expr
 
@@ -148,7 +148,7 @@ def comparison(tokens):
             left=expr,
             oper=oper['value'],
             right=right,
-            token=token,
+            token=oper,
         )
     return expr
 
@@ -162,7 +162,7 @@ def equality(tokens):
             left=expr,
             oper=oper['value'],
             right=right,
-            token=token,
+            token=oper,
         )
     return expr
 

--- a/parser.py
+++ b/parser.py
@@ -221,11 +221,9 @@ def declareStmt(tokens):
     return ExprStmt('declare', expr)
 
 def assignStmt(tokens):
-    name = identifier(tokens).name
-    expectElseError(tokens, '<-', "after name")
-    expr = expression(tokens)
+    expr = assignment(tokens)
     expectElseError(tokens, '\n', "after statement")
-    return Assign('assign', name, expr)
+    return ExprStmt('assign', expr)
 
 def caseStmt(tokens):
     expectElseError(tokens, 'OF', "after CASE")

--- a/parser.py
+++ b/parser.py
@@ -78,17 +78,20 @@ def literal(tokens):
         token=token,
     )
 
+def unary(tokens):
+    oper = consume(tokens)
+    right = expression(tokens)
+    return makeExpr(
+        oper=oper['value'],
+        right=right,
+        token=oper,
+    )
+    
 def value(tokens):
     token = check(tokens)
     # Unary expressions
     if token['word'] in ('-',):
-        oper = consume(tokens)
-        right = expression(tokens)
-        return makeExpr(
-            oper=oper['value'],
-            right=right,
-            token=oper,
-        )
+        return unary(tokens)
     # A single value
     if check(tokens)['type'] in ['INTEGER', 'STRING']:
         return literal(tokens)

--- a/parser.py
+++ b/parser.py
@@ -86,7 +86,30 @@ def unary(tokens):
         right=right,
         token=oper,
     )
-    
+
+def nameExpr(tokens):
+    name = identifier(tokens)
+    expr = makeExpr(
+        frame=NULL,
+        name=name.name,
+        token=name,
+    )
+    # Function call
+    args = []
+    if match(tokens, '('):
+        arg = expression(tokens)
+        args += [arg]
+        while match(tokens, ','):
+            arg = expression(tokens)
+            args += [arg]
+        expectElseError(tokens, ')', "after '('")
+        expr = makeExpr(
+            callable=expr,
+            args=args,
+            token=name,
+        )
+    return expr
+
 def value(tokens):
     token = check(tokens)
     # Unary expressions
@@ -101,27 +124,7 @@ def value(tokens):
         expectElseError(tokens, ')', "after '('")
         return expr
     elif token['type'] == 'name':
-        name = identifier(tokens)
-        expr = makeExpr(
-            frame=NULL,
-            name=name.name,
-            token=name,
-        )
-        # Function call
-        args = []
-        if match(tokens, '('):
-            arg = expression(tokens)
-            args += [arg]
-            while match(tokens, ','):
-                arg = expression(tokens)
-                args += [arg]
-            expectElseError(tokens, ')', "after '('")
-            expr = makeExpr(
-                callable=expr,
-                args=args,
-                token=name,
-            )
-        return expr
+        return nameExpr(tokens)
     else:
         raise ParseError("Unexpected token", token)
 

--- a/resolver.py
+++ b/resolver.py
@@ -192,9 +192,9 @@ def verifyFunction(frame, stmt):
         stmtType = procstmt.accept(local, verify)
         if stmtType:
             hasReturn = True
-            expectTypeElseError(stmtType, stmt.returnType, token=stmt.name)
+            expectTypeElseError(stmtType, stmt.returnType, token=stmt.name.token())
     if not hasReturn:
-        raise LogicError("No RETURN in function", stmt.name)
+        raise LogicError("No RETURN in function", stmt.name.token())
     # Declare function in frame
     frame.declare(stmt.name, stmt.returnType)
     frame.setValue(stmt.name, Function(

--- a/resolver.py
+++ b/resolver.py
@@ -3,7 +3,7 @@ from builtin import add, sub, mul, div
 from builtin import LogicError
 from builtin import NULL
 from lang import TypedValue, Frame, Function, Procedure
-from lang import Literal, Declare, Unary, Binary, Get, Call
+from lang import Literal, Declare, Unary, Binary, Get, Call, Assign
 
 
 
@@ -65,6 +65,11 @@ def resolveBinary(frame, expr):
         expectTypeElseError(righttype, 'INTEGER', token=expr.right.token())
         return 'INTEGER'
 
+def resolveAssign(frame, expr):
+    declaredElseError(frame, expr.name)
+    exprType = expr.expr.accept(frame, resolve)
+    expectTypeElseError(exprType, frame.getType(expr.name), token=expr.token())
+
 def resolveGet(frame, expr):
     """Insert frame into Get expr"""
     assert isinstance(expr, Get), "Not a Get Expr"
@@ -113,6 +118,8 @@ def resolve(frame, expr):
         return expr.accept(frame, resolveUnary)
     elif isinstance(expr, Binary):
         return expr.accept(frame, resolveBinary)
+    elif isinstance(expr, Assign):
+        return expr.accept(frame, resolveAssign)
     elif isinstance(expr, Get):
         return expr.accept(frame, resolveGet)
     elif isinstance(expr, Call):

--- a/resolver.py
+++ b/resolver.py
@@ -15,16 +15,16 @@ def isProcedure(callable):
 def isFunction(callable):
     return isinstance(callable, Function)
 
-def expectTypeElseError(exprtype, expected, name=None):
+def expectTypeElseError(exprtype, expected, *, token=None):
     if exprtype != expected:
         if not name: name = exprtype
-        raise LogicError(f"{exprtype} <> {expected}", name)
+        raise LogicError(f"{exprtype} <> {expected}", token)
 
-def declaredElseError(frame, name, errmsg="Undeclared", declaredType=None):
+def declaredElseError(frame, name, errmsg="Undeclared", declaredType=None, *, token=None):
     if not frame.has(name):
-        raise LogicError(errmsg, name)
+        raise LogicError(errmsg, name, token)
     if declaredType:
-        expectTypeElseError(frame.getType(name), declaredType)
+        expectTypeElseError(frame.getType(name), declaredType, token=token)
 
 def value(frame, expr):
     """Return the value of a Literal"""
@@ -47,7 +47,7 @@ def resolveDeclare(frame, expr):
 def resolveUnary(frame, expr):
     righttype = expr.right.accept(frame, resolve)
     if expr.oper is sub:
-        expectTypeElseError(righttype, 'INTEGER')
+        expectTypeElseError(righttype, 'INTEGER', token=expr.right,token())
         return 'INTEGER'
     else:
         raise ValueError("Unexpected oper {expr.oper}")
@@ -56,13 +56,13 @@ def resolveBinary(frame, expr):
     lefttype = expr.left.accept(frame, resolve)
     righttype = expr.right.accept(frame, resolve)
     if expr.oper in (gt, gte, lt, lte, ne, eq):
-        expectTypeElseError(lefttype, 'INTEGER')
-        expectTypeElseError(righttype, 'INTEGER')
+        expectTypeElseError(lefttype, 'INTEGER', token=expr.left.token())
+        expectTypeElseError(righttype, 'INTEGER', token=expr.right.token())
         return 'BOOLEAN'
     if expr.oper in (add, sub, mul, div):
         # TODO: Handle REAL type
-        expectTypeElseError(lefttype, 'INTEGER')
-        expectTypeElseError(righttype, 'INTEGER')
+        expectTypeElseError(lefttype, 'INTEGER', token=expr.left.token())
+        expectTypeElseError(righttype, 'INTEGER', token=expr.right.token())
         return 'INTEGER'
 
 def resolveGet(frame, expr):
@@ -75,14 +75,14 @@ def resolveProcCall(frame, expr):
     expr.callable.accept(frame, resolveGet)
     callable = frame.getValue(expr.callable.name)
     if not isProcedure(callable):
-        raise LogicError("Not PROCEDURE", expr.callable.name)
+        raise LogicError("Not PROCEDURE", token=expr.callable.token())
     resolveCall(frame, expr)
 
 def resolveFuncCall(frame, expr):
     expr.callable.accept(frame, resolveGet)
     callable = frame.getValue(expr.callable.name)
     if not isFunction(callable):
-        raise LogicError("Not FUNCTION", expr.callable.name)
+        raise LogicError("Not FUNCTION", token=expr.callable.token())
     resolveCall(frame, expr)
     
 def resolveCall(frame, expr):
@@ -96,13 +96,13 @@ def resolveCall(frame, expr):
     if numArgs != numParams:
         raise LogicError(
             f"Expected {numParams} args, got {numArgs}",
-            None,
+            token=expr.callable.token(),
         )
     # Type-check arguments
     for arg, param in zip(expr.args, callable.params):
         # param is a slot from either local or frame
         argtype = arg.accept(frame, resolve)
-        expectTypeElseError(argtype, param.type)
+        expectTypeElseError(argtype, param.type, token=arg.token())
 
 def resolve(frame, expr):
     if isinstance(expr, Literal):
@@ -135,7 +135,7 @@ def verifyInput(frame, stmt):
 def verifyAssign(frame, stmt):
     declaredElseError(frame, stmt.name)
     exprtype = stmt.expr.accept(frame, resolve)
-    expectTypeElseError(exprtype, frame.getType(stmt.name))
+    expectTypeElseError(exprtype, frame.getType(stmt.name), token=stmt.expr.token())
 
 def verifyCase(frame, stmt):
     stmt.cond.accept(frame, resolve)
@@ -144,8 +144,8 @@ def verifyCase(frame, stmt):
         stmt.fallback.accept(frame, verify)
 
 def verifyIf(frame, stmt):
-    stmt.cond.accept(frame, resolve)
-    expectTypeElseError(stmt.cond, 'BOOLEAN')
+    condType = stmt.cond.accept(frame, resolve)
+    expectTypeElseError(condType, 'BOOLEAN', token=stmt.cond.token())
     verifyStmts(frame, stmt.stmts[True])
     if stmt.fallback:
         verifyStmts(frame, stmt.fallback)
@@ -154,7 +154,7 @@ def verifyLoop(frame, stmt):
     if stmt.init:
         stmt.init.accept(frame, verify)
     condtype = stmt.cond.accept(frame, resolve)
-    expectTypeElseError(condtype, 'BOOLEAN')
+    expectTypeElseError(condtype, 'BOOLEAN', token=stmt.cond.token())
     verifyStmts(frame, stmt.stmts)
 
 def verifyProcedure(frame, stmt):
@@ -163,7 +163,7 @@ def verifyProcedure(frame, stmt):
     for i, expr in enumerate(stmt.params):
         if stmt.passby == 'BYREF':
             exprtype = expr.accept(local, resolveDeclare)
-            expectTypeElseError(exprtype, frame.getType(expr.name))
+            expectTypeElseError(exprtype, frame.getType(expr.name), token=expr.token())
             # Reference frame vars in local
             local.setValue(expr.name, frame.getValue(expr.name))
         else:
@@ -190,9 +190,9 @@ def verifyFunction(frame, stmt):
         stmtType = procstmt.accept(local, verify)
         if stmtType:
             hasReturn = True
-            expectTypeElseError(stmtType, stmt.returnType, stmt.name)
+            expectTypeElseError(stmtType, stmt.returnType, token=stmt.name)
     if not hasReturn:
-        raise LogicError("No RETURN in function", None)
+        raise LogicError("No RETURN in function", stmt.name)
     # Declare function in frame
     frame.declare(stmt.name, stmt.returnType)
     frame.setValue(stmt.name, Function(

--- a/resolver.py
+++ b/resolver.py
@@ -2,7 +2,7 @@ from builtin import lt, lte, gt, gte, ne, eq
 from builtin import add, sub, mul, div
 from builtin import LogicError
 from builtin import NULL
-from lang import TypedValue, Frame, Function, Procedure
+from lang import Frame, Function, Procedure
 from lang import Literal, Declare, Unary, Binary, Get, Call, Assign
 
 
@@ -138,11 +138,6 @@ def verifyOutput(frame, stmt):
 
 def verifyInput(frame, stmt):
     declaredElseError(frame, stmt.name)
-
-def verifyAssign(frame, stmt):
-    declaredElseError(frame, stmt.name)
-    exprtype = stmt.expr.accept(frame, resolve)
-    expectTypeElseError(exprtype, frame.getType(stmt.name), token=stmt.expr.token())
 
 def verifyCase(frame, stmt):
     stmt.cond.accept(frame, resolve)

--- a/resolver.py
+++ b/resolver.py
@@ -17,7 +17,7 @@ def isFunction(callable):
 
 def expectTypeElseError(exprtype, expected, *, token=None):
     if exprtype != expected:
-        if not name: name = exprtype
+        if not token: token = exprtype
         raise LogicError(f"{exprtype} <> {expected}", token)
 
 def declaredElseError(frame, name, errmsg="Undeclared", declaredType=None, *, token=None):
@@ -47,7 +47,7 @@ def resolveDeclare(frame, expr):
 def resolveUnary(frame, expr):
     righttype = expr.right.accept(frame, resolve)
     if expr.oper is sub:
-        expectTypeElseError(righttype, 'INTEGER', token=expr.right,token())
+        expectTypeElseError(righttype, 'INTEGER', token=expr.right.token())
         return 'INTEGER'
     else:
         raise ValueError("Unexpected oper {expr.oper}")

--- a/resolver.py
+++ b/resolver.py
@@ -225,7 +225,7 @@ def verify(frame, stmt):
     elif stmt.rule == 'declare':
         stmt.expr.accept(frame, resolveDeclare)
     elif stmt.rule == 'assign':
-        stmt.accept(frame, verifyAssign)
+        stmt.expr.accept(frame, resolveAssign)
     elif stmt.rule == 'case':
         stmt.accept(frame, verifyCase)
     elif stmt.rule == 'if':

--- a/resolver.py
+++ b/resolver.py
@@ -217,10 +217,6 @@ def verify(frame, stmt):
         stmt.accept(frame, verifyOutput)
     if stmt.rule == 'input':
         stmt.accept(frame, verifyInput)
-    elif stmt.rule == 'declare':
-        stmt.expr.accept(frame, resolveDeclare)
-    elif stmt.rule == 'assign':
-        stmt.expr.accept(frame, resolveAssign)
     elif stmt.rule == 'case':
         stmt.accept(frame, verifyCase)
     elif stmt.rule == 'if':
@@ -229,14 +225,14 @@ def verify(frame, stmt):
         stmt.accept(frame, verifyLoop)
     elif stmt.rule == 'procedure':
         stmt.accept(frame, verifyProcedure)
-    elif stmt.rule == 'call':
-        stmt.expr.accept(frame, resolveProcCall)
     elif stmt.rule == 'function':
         stmt.accept(frame, verifyFunction)
     elif stmt.rule == 'file':
         stmt.accept(frame, verifyFile)
-    elif stmt.rule == 'return':
+    elif stmt.rule in ('assign', 'declare', 'return'):
         return stmt.expr.accept(frame, resolve)
+    elif stmt.rule == 'call':
+        stmt.expr.accept(frame, resolveProcCall)
 
 
 


### PR DESCRIPTION
Earlier, we broke error reporting when I decided to avoid the use of tokens in the resolver and interpreter. Error messages still appear, but we have no idea where in the code they are coming from.

Now that the code is better organized and more clearly structured, let's restore it.

How are we going to report errors from the resolver and interpreter without tokens? We will probably still need them, but they can't be a part of the resolution/execution path.