### PR TITLE
18b Logical operators

### DIFF
--- a/builtin.py
+++ b/builtin.py
@@ -41,7 +41,9 @@ class LogicError(PseudoError):
 def add(x, y):
     return x + y
 
-def sub(x, y):
+def sub(x, y=None):
+    if y is None:
+        return -x
     return x - y
 
 def mul(x, y):

--- a/builtin.py
+++ b/builtin.py
@@ -68,6 +68,15 @@ def ne(x, y):
 def eq(x, y):
     return x == y
 
+def AND(x, y):
+    return x and y
+
+def OR(x, y):
+    return x or y
+
+def NOT(x):
+    return not x
+
 
 
 # Token types
@@ -104,6 +113,9 @@ OPERATORS = {
     '>=': gte,
     '<>': ne,
     '=': eq,
+    'AND': AND,
+    'OR': OR,
+    'NOT': NOT,
 }
 
 SYMBOLS = [',', ':']

--- a/main.pseudo
+++ b/main.pseudo
@@ -1,5 +1,5 @@
 PROCEDURE TestBool(Succeeded : BOOLEAN)
-    IF Succeeded = TRUE AND 1 = 1
+    IF Succeeded = TRUE OR NOT 1 = 1
       THEN
         OUTPUT "Yay!"
       ELSE

--- a/main.pseudo
+++ b/main.pseudo
@@ -1,5 +1,5 @@
 PROCEDURE TestBool(Succeeded : BOOLEAN)
-    IF Succeeded = TRUE OR NOT 1 = 1
+    IF Succeeded = TRUE AND NOT 1 = 1
       THEN
         OUTPUT "Yay!"
       ELSE

--- a/main.pseudo
+++ b/main.pseudo
@@ -1,5 +1,5 @@
 PROCEDURE TestBool(Succeeded : BOOLEAN)
-    IF Succeeded = TRUE
+    IF Succeeded = TRUE AND 1 = 1
       THEN
         OUTPUT "Yay!"
       ELSE

--- a/parser.py
+++ b/parser.py
@@ -120,7 +120,7 @@ def nameExpr(tokens):
 def value(tokens):
     token = check(tokens)
     # Unary expressions
-    if token.word in ('-',):
+    if token.word in ('-', 'NOT'):
         return unary(tokens)
     # A single value
     if check(tokens).type in TYPES:
@@ -190,8 +190,22 @@ def equality(tokens):
         )
     return expr
 
-def expression(tokens):
+def logical(tokens):
+    # AND, OR
     expr = equality(tokens)
+    while not atEnd(tokens) and check(tokens).word in ('AND', 'OR'):
+        oper = consume(tokens)
+        right = equality(tokens)
+        expr = makeExpr(
+            left=expr,
+            oper=oper.value,
+            right=right,
+            token=oper,
+        )
+    return expr
+
+def expression(tokens):
+    expr = logical(tokens)
     return expr
 
 def assignment(tokens):

--- a/resolver.py
+++ b/resolver.py
@@ -51,7 +51,8 @@ def resolveUnary(frame, expr):
         return 'INTEGER'
     if expr.oper is NOT:
         expectTypeElseError(righttype, 'BOOLEAN', token=expr.right.token())
-    raise ValueError("Unexpected oper {expr.oper}")
+        return 'BOOLEAN'
+    raise ValueError(f"Unexpected oper {expr.oper}")
 
 def resolveBinary(frame, expr):
     lefttype = expr.left.accept(frame, resolve)

--- a/resolver.py
+++ b/resolver.py
@@ -159,7 +159,6 @@ def verifyCase(frame, stmt):
         stmt.fallback.accept(frame, verify)
 
 def verifyIf(frame, stmt):
-    breakpoint()
     condType = stmt.cond.accept(frame, resolve)
     expectTypeElseError(condType, 'BOOLEAN', token=stmt.cond.token())
     verifyStmts(frame, stmt.stmtMap[True])

--- a/resolver.py
+++ b/resolver.py
@@ -1,3 +1,4 @@
+from builtin import AND, OR, NOT
 from builtin import lt, lte, gt, gte, ne, eq
 from builtin import add, sub, mul, div
 from builtin import LogicError
@@ -48,12 +49,17 @@ def resolveUnary(frame, expr):
     if expr.oper is sub:
         expectTypeElseError(righttype, 'INTEGER', token=expr.right.token())
         return 'INTEGER'
-    else:
-        raise ValueError("Unexpected oper {expr.oper}")
+    if expr.oper is NOT:
+        expectTypeElseError(righttype, 'BOOLEAN', token=expr.right.token())
+    raise ValueError("Unexpected oper {expr.oper}")
 
 def resolveBinary(frame, expr):
     lefttype = expr.left.accept(frame, resolve)
     righttype = expr.right.accept(frame, resolve)
+    if expr.oper in (AND, OR):
+        expectTypeElseError(lefttype, 'BOOLEAN', token=expr.left.token())
+        expectTypeElseError(righttype, 'BOOLEAN', token=expr.right.token())
+        return 'BOOLEAN'
     if expr.oper in (ne, eq):
         if lefttype not in ('BOOLEAN', 'INTEGER'):
             raise LogicError(f"Invalid comparison type", token=expr.left.token())
@@ -153,6 +159,7 @@ def verifyCase(frame, stmt):
         stmt.fallback.accept(frame, verify)
 
 def verifyIf(frame, stmt):
+    breakpoint()
     condType = stmt.cond.accept(frame, resolve)
     expectTypeElseError(condType, 'BOOLEAN', token=stmt.cond.token())
     verifyStmts(frame, stmt.stmtMap[True])

--- a/scanner.py
+++ b/scanner.py
@@ -95,6 +95,9 @@ def scan(src):
                     token = makeToken(code, 'BOOLEAN', text, False)
                 else:
                     raise ValueError(f"Unrecognised value {text}")
+            elif text in OPERATORS:  # AND, OR, NOT
+                oper = OPERATORS.get(text, None)
+                token = makeToken(code, 'symbol', text, oper)
             else:
                 token = makeToken(code, 'name', text, None)
         elif char.isdigit():


### PR DESCRIPTION
Now that our interpreter can understand TRUE and FALSE, let's implement AND, OR, and NOT operators.

We start with scanning. First let's add the operators in `builtin.py` and have them recognised as operators:
https://github.com/nyjc-computing/pseudo/blob/4241f231018f605311a67ad762c9db3e4cf5e8cb/builtin.py#L71-L78
https://github.com/nyjc-computing/pseudo/blob/4241f231018f605311a67ad762c9db3e4cf5e8cb/builtin.py#L105-L119

Then enable scanning them:
https://github.com/nyjc-computing/pseudo/blob/4241f231018f605311a67ad762c9db3e4cf5e8cb/scanner.py#L98-L100