### PR TITLE
18c Fix: Logical operators

### DIFF
--- a/main.pseudo
+++ b/main.pseudo
@@ -1,5 +1,5 @@
 PROCEDURE TestBool(Succeeded : BOOLEAN)
-    IF Succeeded = TRUE AND NOT 1 = 1
+    IF Succeeded = TRUE AND NOT -1 = -1
       THEN
         OUTPUT "Yay!"
       ELSE

--- a/main.pseudo
+++ b/main.pseudo
@@ -1,5 +1,5 @@
 PROCEDURE TestBool(Succeeded : BOOLEAN)
-    IF Succeeded = TRUE AND NOT -1 = -1
+    IF Succeeded = TRUE AND NOT (-1 = -1)
       THEN
         OUTPUT "Yay!"
       ELSE

--- a/parser.py
+++ b/parser.py
@@ -99,7 +99,7 @@ def nameExpr(tokens):
     expr = makeExpr(
         frame=NULL,
         name=name.name,
-        token=name,
+        token=name.token(),
     )
     # Function call
     args = []
@@ -113,7 +113,7 @@ def nameExpr(tokens):
         expr = makeExpr(
             callable=expr,
             args=args,
-            token=name,
+            token=name.token(),
         )
     return expr
 

--- a/parser.py
+++ b/parser.py
@@ -87,7 +87,7 @@ def literal(tokens):
 
 def unary(tokens):
     oper = consume(tokens)
-    right = expression(tokens)
+    right = value(tokens)
     return makeExpr(
         oper=oper.value,
         right=right,


### PR DESCRIPTION
Oops, one bug that slipped testing! 

Test code:
```
PROCEDURE TestBool(Succeeded : BOOLEAN)
    IF Succeeded = TRUE AND NOT (-1 = -1)
      THEN
        OUTPUT "Yay!"
      ELSE
        OUTPUT "Awww!"
    ENDIF
ENDPROCEDURE

CALL TestBool(TRUE)
```

This doesn't work, because ...
https://github.com/nyjc-computing/pseudo/blob/660d9fd53224954cf78282b4d79d06271ef7f4dc/parser.py#L88-L95

Our `unary()` parser is too generous, parsing an entire expression, which gives us `-(1 = -1)` instead of `((-1) = (-1))`.

Simple fix: parse with `value()` instead of `expression()`:
e4bdb4a9f9beaee3c06baadca6f707016a52bb06
