### PR TITLE
31d Defining behaviour: Container types and assignment

### DIFF
--- a/CONTENTS.md
+++ b/CONTENTS.md
@@ -80,3 +80,4 @@ If you are a beginner programmer, I hope this gitbook teaches you soemthing you 
 - [31a Defining behaviour: Cleaning up (again)](https://github.com/nyjc-computing/pseudo-9608/pull/96)
 - [31b Defining behaviour: EOF handling and Returns](https://github.com/nyjc-computing/pseudo-9608/pull/97)
 - [31c Defining behaviour: Object hierarchy](https://github.com/nyjc-computing/pseudo-9608/pull/98)
+- [31d Defining behaviour: Container types and assignment](https://github.com/nyjc-computing/pseudo-9608/pull/104)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -164,7 +164,7 @@ Variables of a custom data type can be assigned to each other. Individual data i
 >     DECLARE Index : INTEGER
 >     
 >     Pupil1.Surname <- "Johnson"
->     Pupil1.Firstname <- "Leroy"
+>     Pupil1.FirstName <- "Leroy"
 >     Pupil1.DateOfBirth <- 02/01/2005
 >     Pupil1.YearGroup <- 6
 >     Pupil1.FormGroup <- ꞌAꞌ

--- a/pseudocode/__init__.py
+++ b/pseudocode/__init__.py
@@ -63,7 +63,7 @@ def report(lines: Iterable[str], err: builtin.PseudoError) -> None:
     errType = type(err).__name__ + ':'
     if err.line:
         lineinfo = f"[Line {err.line}]"
-        print(lineinfo, lines[err.line - 1])  # type: ignore
+        print(lineinfo, lines[err.line - 1] if lines else '')  # type: ignore
     if err.column:
         leftmargin = len(lineinfo) + err.column
         print((' ' * leftmargin) + '^')
@@ -121,7 +121,6 @@ class Pseudo:
         """Executes code represented by the src string."""
         result: Result = {
             'lines': [],
-            # 'frame': self.frame,
             'env': self.env,
             'error': None,
         }

--- a/pseudocode/__init__.py
+++ b/pseudocode/__init__.py
@@ -3,7 +3,7 @@
 Pseudo
     Interprets code from a file or string
 """
-from dataclasses import dataclass
+
 import os
 import sys
 from typing import Optional

--- a/pseudocode/builtin.py
+++ b/pseudocode/builtin.py
@@ -9,13 +9,11 @@ class PseudoError(Exception):
     def __init__(self, msg, token, line=None) -> None:
         super().__init__(msg)
         self.token = token
-        self.line = line
-        self.column = None
-        if token:
-            self.line = token.line
-            self.column = token.column
-        else:
-            self.line = None
+        self.line = line or token.line
+
+    @property
+    def column(self):
+        return hasattr(self.token, "column") and self.token.column
 
     def msg(self) -> str:
         return self.args[0]

--- a/pseudocode/lang/object.py
+++ b/pseudocode/lang/object.py
@@ -149,9 +149,13 @@ class Container(PseudoValue):
 
     Attributes
     ----------
+    - type
+      Type name of the container
+      e.g. Student, e.g. ARRAY[1:3] OF INTEGER
     - data
-        A MutableMapping used to map keys to TypedValues
+      A MutableMapping used to map keys to TypedValues
     """
+    type: t.Type
     data: MutableMapping
 
 
@@ -179,7 +183,7 @@ class Array(Container):
     setValue(index, value)
         updates the value associated with the index
     """
-    __slots__ = ("ranges", "data")
+    __slots__ = ("ranges", "data", "type")
 
     def __init__(self, ranges: t.IndexRanges, type: t.Type) -> None:
         self.ranges = ranges
@@ -262,7 +266,7 @@ class Object(Container):
     setValue(name, value)
         updates the value associated with the name
     """
-    __slots__ = ("data", )
+    __slots__ = ("data", "type")
 
     def __init__(self) -> None:
         self.data: NameMap = {}

--- a/pseudocode/lang/object.py
+++ b/pseudocode/lang/object.py
@@ -16,10 +16,13 @@ from abc import ABC
 from dataclasses import dataclass
 from itertools import product
 from typing import (
+    Dict,
     Iterator,
+    Mapping,
     MutableMapping,
     Optional,
     Sequence,
+    TypedDict,
     Union,
 )
 
@@ -48,13 +51,23 @@ IndexMap = MutableMapping[t.IndexKey, "TypedValue"]
 Params = Sequence["TypedValue"]
 
 
+class ArrayMetadata(TypedDict, total=False):
+    """The metadata held by the TypedValue for an Array"""
+    size: t.IndexRanges
+    type: t.Type
+
+
+ObjectMetadata = Dict[t.Names, t.Type]
+
+
 @dataclass
 class TypedValue:
     """All pseudocode values are encapsulated in a TypedValue.
-    Each TypedValue has a type and a value.
+    Each TypedValue has a type and a value, with optional metadata.
     """
-    __slots__ = ("type", "value")
+    __slots__ = ("type", "metadata", "value")
     type: t.Type
+    # metadata: Mapping
     value: Optional[Value]
 
     def __repr__(self) -> str:

--- a/pseudocode/lang/object.py
+++ b/pseudocode/lang/object.py
@@ -67,8 +67,12 @@ class TypedValue:
     """
     __slots__ = ("type", "metadata", "value")
     type: t.Type
-    # metadata: Mapping
+    # metadata: Optional[Mapping]
     value: Optional[Value]
+    def __init__(self, type: t.Type, value: Optional[Value] = None, metadata: Optional[Mapping] = None) -> None:
+        self.type = type
+        self.value = value
+        self.metadata = metadata or {}
 
     def __repr__(self) -> str:
         return f"<{self.type}: {repr(self.value)}>"

--- a/pseudocode/lang/object.py
+++ b/pseudocode/lang/object.py
@@ -13,7 +13,7 @@ Frame
 """
 
 from abc import ABC
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import product
 from typing import (
     Dict,
@@ -65,14 +65,9 @@ class TypedValue:
     """All pseudocode values are encapsulated in a TypedValue.
     Each TypedValue has a type and a value, with optional metadata.
     """
-    __slots__ = ("type", "metadata", "value")
     type: t.Type
-    # metadata: Optional[Mapping]
-    value: Optional[Value]
-    def __init__(self, type: t.Type, value: Optional[Value] = None, metadata: Optional[Mapping] = None) -> None:
-        self.type = type
-        self.value = value
-        self.metadata = metadata or {}
+    value: Optional[Value] = None
+    metadata: Optional[Mapping] = field(default_factory=dict)
 
     def __repr__(self) -> str:
         return f"<{self.type}: {repr(self.value)}>"

--- a/pseudocode/lang/types.py
+++ b/pseudocode/lang/types.py
@@ -13,6 +13,7 @@ __all__ = [
     'Type',
     'Key',
     'NameKey',
+    'Names',
     'IndexKey',
     'IndexRange',
     'IndexRanges',
@@ -23,6 +24,8 @@ Type = str  # pseudocode type, whether built-in or declared
 Key = Hashable
 NameKey = str  # for Object/Frame
 IndexKey = Tuple[int, ...]  # for Array
+
+Names = Sequence[NameKey]
 
 IndexRange = Tuple[int, int]  # Array ranges (start, end)
 IndexRanges = Sequence[IndexRange]


### PR DESCRIPTION
Hear me out: what if containers had types?

Suppse every container had a `type` attribute. A Student object would have `Student.type == "Student"`. An Array might have type `ARRAY`, or `ARRAY[1:3] OF INTEGER`. 

I imagine the Container protocol would look something like this:
https://github.com/nyjc-computing/pseudo-9608/blob/3bdf489b985911caa08996a570ed59d90a1d6190/pseudocode/lang/object.py#L146-L159

Why do we want this, or even need this? I'm looking at the part of the 9608 pseudocode reference that requires support for statements like these:

```
DECLARE NoughtsAndCrosses : ARRAY[1:3,1:3] OF STRING
DECLARE SavedGame : ARRAY[1:3,1:3] OF STRING
DECLARE i : INTEGER
DECLARE j : INTEGER

FOR i <- 1 TO 3
    FOR j <- 1 TO 3
        IF MOD(i, 2) = MOD(j, 2)
          THEN
            NoughtsAndCrosses[i, j] <- "X"
          ELSE
            NoughtsAndCrosses[i, j] <- "O"
        ENDIF
    ENDFOR
ENDFOR

SavedGame <- NoughtsAndCrosses

FOR i <- 1 TO 3
    FOR j <- 1 TO 3
        OUTPUT SavedGame[i, j]
    ENDFOR
ENDFOR

TYPE Student
    DECLARE Surname : STRING
    DECLARE FirstName : STRING
    DECLARE YearGroup : INTEGER
ENDTYPE

DECLARE Pupil1 : Student
DECLARE Pupil2 : Student
Pupil1.Surname <- "Johnson"
Pupil1.Firstname <- "Leroy"
Pupil1.YearGroup <- 6
Pupil2 <- Pupil1

OUTPUT Pupil2.Surname
OUTPUT Pupil2.FirstName
OUTPUT Pupil2.YearGroup
```

tl;dr Pseudo needs to support Array and Object assignments. Currently, this works:

```
$ pseudo main.pseudo 
X
O
X
O
X
O
X
O
X
Johnson
Leroy
6
```

We lean heavily on Python's object model to make this work; internally, within the global frame, the `Pupil1` and `Pupil2` names point to the same Object, while the `NoughtsAndCrosses` and `SavedGame` names point to the same Array.

But when we change the code a little:

```
DECLARE NoughtsAndCrosses : ARRAY[1:3,1:3] OF STRING
DECLARE SavedGame : ARRAY[1:4,1:4] OF STRING
DECLARE i : INTEGER
DECLARE j : INTEGER

FOR i <- 1 TO 3
    FOR j <- 1 TO 3
        IF MOD(i, 2) = MOD(j, 2)
          THEN
            NoughtsAndCrosses[i, j] <- "X"
          ELSE
            NoughtsAndCrosses[i, j] <- "O"
        ENDIF
    ENDFOR
ENDFOR

SavedGame <- NoughtsAndCrosses
NoughtsAndCrosses[2, 2] <- "O"

FOR i <- 1 TO 3
    FOR j <- 1 TO 3
        OUTPUT SavedGame[i, j]
    ENDFOR
ENDFOR

TYPE Student
    DECLARE Surname : STRING
    DECLARE FirstName : STRING
    DECLARE YearGroup : INTEGER
ENDTYPE

DECLARE Pupil1 : Student
DECLARE Pupil2 : Student
Pupil1.Surname <- "Johnson"
Pupil1.FirstName <- "Leroy"
Pupil1.YearGroup <- 6
Pupil2 <- Pupil1
Pupil1.FirstName <- "LEEROOOOYYYYYY"

OUTPUT Pupil2.Surname
OUTPUT Pupil2.FirstName
OUTPUT Pupil2.YearGroup
```

We get this:

```
$ pseudo main.pseudo 
X
O
X
O
O
O
X
O
X
Johnson
LEEROOOOYYYYYY
6
```

That's not quite how things are supposed to work in Pseudo. DECLAREing a name means that memory is set aside for its data, so Array and Object assignment should result in *copying*, not *referencing* of data. After the assignment, mutations to `Pupil1` and `NoughtsAndCrosses` should not be reflected in the copies.

Not to mention that array assignment for arrays with different sizes is not supported in Pseudo.
We'll fix all this in this chapter.